### PR TITLE
Remove rust catch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,24 +171,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro2"
-version = "0.4.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
-dependencies = [
- "unicode-xid",
-]
-
-[[package]]
-name = "quote"
-version = "0.6.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce23b6b870e8f94f81fb0a363d65d86675884b34a09043c81e5562f11c1f8e1"
-dependencies = [
- "proc-macro2",
-]
-
-[[package]]
 name = "rayon"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -219,17 +201,6 @@ version = "0.1.0"
 dependencies = [
  "png",
  "rayon",
- "rust-catch",
-]
-
-[[package]]
-name = "rust-catch"
-version = "0.3.0"
-source = "git+https://github.com/gdunton/rust-catch?rev=HEAD#8052a8f769898c428622b22216a5b35854b9b0b3"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -237,20 +208,3 @@ name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
-
-[[package]]
-name = "syn"
-version = "0.15.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ca4b3b69a77cbe1ffc9e198781b7acb0c7365a883670e8f1c1bc66fba79a5c5"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-xid",
-]
-
-[[package]]
-name = "unicode-xid"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,5 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-rust-catch = { git = "https://github.com/gdunton/rust-catch", rev = "HEAD" }
 png = "0.16.7"
 rayon = "1.3.1"

--- a/README.md
+++ b/README.md
@@ -18,7 +18,3 @@ cargo build
 cargo run
 cargo test
 ```
-
-## Tests
-
-The project has built in tests using my testing framework [rust-catch](https://github.com/guydunton/rust-catch).

--- a/src/canvas/canvas_test.rs
+++ b/src/canvas/canvas_test.rs
@@ -1,41 +1,32 @@
-#[cfg(test)]
-mod canvas_test {
-    use super::super::Canvas;
-    use super::super::Color;
-    use rust_catch::tests;
+use super::{Canvas, Color};
 
-    tests! {
-        test("Can create a canvas") {
-            let c = Canvas::new(10, 20);
-            assert_eq!(c.width(), 10);
-            assert_eq!(c.height(), 20);
-        }
+#[test]
+fn can_create_a_canvas() {
+    let c = Canvas::new(10, 20);
+    assert_eq!(c.width(), 10);
+    assert_eq!(c.height(), 20);
+}
 
-        test("Canvas pixels be set to a color") {
-            let mut c = Canvas::new(10, 20);
-            let red = Color::new(1.0, 0.0, 0.0);
-            c.write_pixel(2, 3, red);
+#[test]
+fn canvas_pixels_be_set_to_a_color() {
+    let mut c = Canvas::new(10, 20);
+    let red = Color::new(1.0, 0.0, 0.0);
+    c.write_pixel(2, 3, red);
 
-            assert_eq!(c.pixel_at(2, 3), red);
-        }
+    assert_eq!(c.pixel_at(2, 3), red);
+}
 
-        test("Canvas can be written to png") {
-            let mut c = Canvas::new(2, 2);
-            let red = Color::new(1.0, 0.0, 0.0);
+#[test]
+fn canvas_can_be_written_to_png() {
+    let mut c = Canvas::new(2, 2);
+    let red = Color::new(1.0, 0.0, 0.0);
 
-            for i in 0..2 {
-                c.write_pixel(i, i, red);
-            }
-
-            let save_buffer = c.get_save_buffer();
-            let expected_buffer = vec![
-                255, 0, 0, 255,
-                0, 0, 0, 255,
-                0, 0, 0, 255,
-                255, 0, 0, 255,
-            ];
-
-            assert_eq!(save_buffer, expected_buffer);
-        }
+    for i in 0..2 {
+        c.write_pixel(i, i, red);
     }
+
+    let save_buffer = c.get_save_buffer();
+    let expected_buffer = vec![255, 0, 0, 255, 0, 0, 0, 255, 0, 0, 0, 255, 255, 0, 0, 255];
+
+    assert_eq!(save_buffer, expected_buffer);
 }

--- a/src/canvas/color_test.rs
+++ b/src/canvas/color_test.rs
@@ -1,42 +1,41 @@
-#[cfg(test)]
-mod color_test {
-    use super::super::Color;
-    use rust_catch::tests;
+use super::Color;
 
-    tests! {
-        test("Retrieving the components of a color works") {
-            let c = Color::new(-0.5, 0.4, 1.7);
-            assert_eq!(c.r(), -0.5);
-            assert_eq!(c.g(), 0.4);
-            assert_eq!(c.b(), 1.7);
+#[test]
+fn retrieving_the_components_of_a_color_works() {
+    let c = Color::new(-0.5, 0.4, 1.7);
+    assert_eq!(c.r(), -0.5);
+    assert_eq!(c.g(), 0.4);
+    assert_eq!(c.b(), 1.7);
 
-            assert_eq!(c, Color::new(-0.5, 0.4, 1.7));
-        }
+    assert_eq!(c, Color::new(-0.5, 0.4, 1.7));
+}
 
-        test("Colors can be added") {
-            let c1 = Color::new(0.9, 0.6, 0.75);
-            let c2 = Color::new(0.7, 0.1, 0.25);
+#[test]
+fn colors_can_be_added() {
+    let c1 = Color::new(0.9, 0.6, 0.75);
+    let c2 = Color::new(0.7, 0.1, 0.25);
 
-            assert_eq!(c1 + c2, Color::new(1.6, 0.7, 1.0));
-        }
+    assert_eq!(c1 + c2, Color::new(1.6, 0.7, 1.0));
+}
 
-        test("Colors can be subtracted") {
-            let c1 = Color::new(0.9, 0.6, 0.75);
-            let c2 = Color::new(0.7, 0.1, 0.25);
+#[test]
+fn colors_can_be_subtracted() {
+    let c1 = Color::new(0.9, 0.6, 0.75);
+    let c2 = Color::new(0.7, 0.1, 0.25);
 
-            assert_eq!(c1 - c2, Color::new(0.2, 0.5, 0.5));
-        }
+    assert_eq!(c1 - c2, Color::new(0.2, 0.5, 0.5));
+}
 
-        test("Colors can be multiplied by scalar") {
-            let c = Color::new(0.2, 0.3, 0.4);
-            assert_eq!(c * 2.0, Color::new(0.4, 0.6, 0.8));
-        }
+#[test]
+fn colors_can_be_multiplied_by_scalar() {
+    let c = Color::new(0.2, 0.3, 0.4);
+    assert_eq!(c * 2.0, Color::new(0.4, 0.6, 0.8));
+}
 
-        test("Colors can be multiplied together") {
-            let c1 = Color::new(1.0, 0.2, 0.4);
-            let c2 = Color::new(0.9, 1.0, 0.1);
+#[test]
+fn colors_can_be_multiplied_together() {
+    let c1 = Color::new(1.0, 0.2, 0.4);
+    let c2 = Color::new(0.9, 1.0, 0.1);
 
-            assert_eq!(c1 * c2, Color::new(0.9, 0.2, 0.04));
-        }
-    }
+    assert_eq!(c1 * c2, Color::new(0.9, 0.2, 0.04));
 }

--- a/src/canvas/mod.rs
+++ b/src/canvas/mod.rs
@@ -12,5 +12,7 @@ pub use canvas_writer::save_canvas;
 pub use color::Color;
 
 // Tests
+#[cfg(test)]
 mod canvas_test;
+#[cfg(test)]
 mod color_test;

--- a/src/maths/matrix_test.rs
+++ b/src/maths/matrix_test.rs
@@ -368,27 +368,27 @@ fn a_shearing_transformation_moves_x_in_proportion_to_y() {
 #[test]
 fn individual_transformations_are_applied_in_sequence() {
     let p = Tuple::point(1.0, 0.0, 1.0);
-    let A = Matrix4x4::rotation_x(std::f64::consts::PI / 2.0);
-    let B = Matrix4x4::scaling(5.0, 5.0, 5.0);
-    let C = Matrix4x4::translation(10.0, 5.0, 7.0);
+    let a = Matrix4x4::rotation_x(std::f64::consts::PI / 2.0);
+    let b = Matrix4x4::scaling(5.0, 5.0, 5.0);
+    let c = Matrix4x4::translation(10.0, 5.0, 7.0);
 
-    let p2 = A * p;
+    let p2 = a * p;
     assert_eq!(p2, Tuple::point(1.0, -1.0, 0.0));
-    let p3 = B * p2;
+    let p3 = b * p2;
     assert_eq!(p3, Tuple::point(5.0, -5.0, 0.0));
-    let p4 = C * p3;
+    let p4 = c * p3;
     assert_eq!(p4, Tuple::point(15.0, 0.0, 7.0));
 }
 
 #[test]
 fn chained_transformations_must_be_applied_in_reverse_order() {
     let p = Tuple::point(1.0, 0.0, 1.0);
-    let A = Matrix4x4::rotation_x(std::f64::consts::PI / 2.0);
-    let B = Matrix4x4::scaling(5.0, 5.0, 5.0);
-    let C = Matrix4x4::translation(10.0, 5.0, 7.0);
+    let a = Matrix4x4::rotation_x(std::f64::consts::PI / 2.0);
+    let b = Matrix4x4::scaling(5.0, 5.0, 5.0);
+    let c = Matrix4x4::translation(10.0, 5.0, 7.0);
 
-    let T = C * B * A;
-    assert_eq!(T * p, Tuple::point(15.0, 0.0, 7.0));
+    let t = c * b * a;
+    assert_eq!(t * p, Tuple::point(15.0, 0.0, 7.0));
 }
 
 #[test]

--- a/src/maths/matrix_test.rs
+++ b/src/maths/matrix_test.rs
@@ -1,493 +1,442 @@
-#[cfg(test)]
-mod matrix_test {
-    use super::super::{Matrix2x2, Matrix3x3, Matrix4x4, Tuple};
-    use crate::maths::{Point, Vector};
-    use rust_catch::tests;
-    use std::f64::consts::PI;
-
-    tests! {
-        test("Can construct a matrix4x4") {
-            let m = Matrix4x4::new(
-                1.0, 2.0, 3.0, 4.0,
-                5.5, 6.5, 7.5, 8.5,
-                9.0, 10.0, 11.0, 12.0,
-                13.5, 14.5, 15.5, 16.5
-            );
-
-            assert_eq!(m.at(0, 0), 1.0);
-            assert_eq!(m.at(0, 3), 4.0);
-            assert_eq!(m.at(1, 0), 5.5);
-        }
-
-        test("Can construct a 2x2 matrix") {
-            let m = Matrix2x2::new(
-                -3.0, 5.0,
-                1.0, -2.0
-            );
-
-            assert_eq!(m.at(0, 0), -3.0);
-            assert_eq!(m.at(0, 1), 5.0);
-            assert_eq!(m.at(1, 0), 1.0);
-            assert_eq!(m.at(1, 1), -2.0);
-        }
-
-        test("Can construct a 3x3 matrix") {
-            let m = Matrix3x3::new(
-                -3.0, 5.0, 0.0,
-                1.0, -2.0, -7.0,
-                0.0, 1.0, 1.0
-            );
-
-            assert_eq!(m.at(0, 0), -3.0);
-            assert_eq!(m.at(1, 1), -2.0);
-            assert_eq!(m.at(2, 2), 1.0);
-        }
-
-        test("We can test the equality of matrices") {
-            let a = Matrix4x4::new(
-                1.0, 2.0, 3.0, 4.0,
-                5.0, 6.0, 7.0, 8.0,
-                9.0, 10.0, 11.0, 12.0,
-                13.0, 14.0, 15.0, 16.0
-            );
-            let b = Matrix4x4::new(
-                1.0, 2.0, 3.0, 4.0,
-                5.0, 6.0, 7.0, 8.0,
-                9.0, 10.0, 11.0, 12.0,
-                13.0, 14.0, 15.0, 16.0,
-            );
-
-            let c = Matrix4x4::new(
-                1.0, 2.0, 3.0, 4.0,
-                5.0, 6.0, 7.0, 8.0,
-                9.0, 8.0, 7.0, 6.0,
-                5.0, 4.0, 3.0, 2.0,
-            );
-
-            assert_eq!(a, b);
-
-            assert_ne!(a, c);
-        }
-
-        test("Matrices can be multiplied together") {
-            let a = Matrix4x4::new(
-                1.0, 2.0, 3.0, 4.0,
-                5.0, 6.0, 7.0, 8.0,
-                9.0, 8.0, 7.0, 6.0,
-                5.0, 4.0, 3.0, 2.0,
-            );
-
-            let b = Matrix4x4::new(
-                -2.0, 1.0, 2.0, 3.0,
-                3.0, 2.0, 1.0, -1.0,
-                4.0, 3.0, 6.0, 5.0,
-                1.0, 2.0, 7.0, 8.0,
-            );
-
-            let expected = Matrix4x4::new(
-                20.0, 22.0, 50.0, 48.0,
-                44.0, 54.0, 114.0, 108.0,
-                40.0, 58.0, 110.0, 102.0,
-                16.0, 26.0, 46.0, 42.0,
-            );
-
-            assert_eq!(a * b, expected);
-        }
-
-        test("Matrices can be multiplied by a tuple") {
-            let m = Matrix4x4::new(
-                1.0, 2.0, 3.0, 4.0,
-                2.0, 4.0, 4.0, 2.0,
-                8.0, 6.0, 4.0, 1.0,
-                0.0, 0.0, 0.0, 1.0
-            );
-
-            let t = Tuple::new(1.0, 2.0, 3.0, 1.0);
-
-            assert_eq!(m * t, Tuple::new(18.0, 24.0, 33.0, 1.0));
-        }
-
-        test("Multiplying a by identity returns a") {
-            let a = Matrix4x4::new(
-                0.0, 1.0, 2.0, 4.0,
-                1.0, 2.0, 4.0, 8.0,
-                2.0, 4.0, 8.0, 16.0,
-                4.0, 8.0, 16.0, 32.0
-            );
-
-            let id = Matrix4x4::identity();
-            assert_eq!(a * id, a);
-        }
-
-        test("Matrices can be transposed") {
-            let a = Matrix4x4::new(
-                0.0, 9.0, 3.0, 0.0,
-                9.0, 8.0, 0.0, 8.0,
-                1.0, 8.0, 5.0, 3.0,
-                0.0, 0.0, 5.0, 8.0,
-            );
-
-            let expected = Matrix4x4::new(
-                0.0, 9.0, 1.0, 0.0,
-                9.0, 8.0, 8.0, 0.0,
-                3.0, 0.0, 5.0, 5.0,
-                0.0, 8.0, 3.0, 8.0,
-            );
-
-            assert_eq!(a.transpose(), expected);
-        }
-
-        test("We can calculate the determinant of a 2x2 matrix") {
-            let m = Matrix2x2::new(
-                1.0, 5.0,
-                -3.0, 2.0
-            );
-
-            assert_eq!(m.determinant(), 17.0);
-        }
-
-        test("Create a submatrix from a 3x3 matrix") {
-            let m = Matrix3x3::new(
-                1.0, 5.0, 0.0,
-                -3.0, 2.0, 7.0,
-                0.0, 6.0, -3.0
-            );
-
-            let result = Matrix2x2::new(
-                -3.0, 2.0,
-                0.0, 6.0
-            );
-
-            assert_eq!(m.submatrix(0, 2), result);
-        }
-
-        test("Get the minor of a matrix3x3") {
-            let a = Matrix3x3::new(
-                3.0, 5.0, 0.0,
-                2.0, -1.0, -7.0,
-                6.0, -1.0, 5.0
-            );
-
-            let b = a.submatrix(1, 0);
-            assert_eq!(b.determinant(), 25.0);
-            assert_eq!(a.minor(1, 0), 25.0);
-        }
-
-        test("Calculate the cofactor of a 3x3 matrix") {
-            let a = Matrix3x3::new(
-                3.0, 5.0, 0.0,
-                2.0, -1.0, -7.0,
-                6.0, -1.0, 5.0
-            );
-
-            assert_eq!(a.minor(0, 0), -12.0);
-            assert_eq!(a.cofactor(0, 0), -12.0);
-            assert_eq!(a.minor(1, 0), 25.0);
-            assert_eq!(a.cofactor(1, 0), -25.0);
-        }
-
-        test("Calculate the determinant of a 3x3 matrix") {
-            let a = Matrix3x3::new(
-                1.0, 2.0, 6.0,
-                -5.0, 8.0, -4.0,
-                2.0, 6.0, 4.0
-            );
-
-            assert_eq!(a.cofactor(0, 0), 56.0);
-            assert_eq!(a.cofactor(0, 1), 12.0);
-            assert_eq!(a.cofactor(0, 2), -46.0);
-            assert_eq!(a.determinant(), -196.0);
-        }
-
-        test("Calculate the determinant of a 4x4 matrix") {
-            let a = Matrix4x4::new(
-                -2.0, -8.0, 3.0, 5.0,
-                -3.0, 1.0, 7.0, 3.0,
-                1.0, 2.0, -9.0, 6.0,
-                -6.0, 7.0, 7.0, -9.0
-            );
-
-            assert_eq!(a.cofactor(0, 0), 690.0);
-            assert_eq!(a.cofactor(0, 1), 447.0);
-            assert_eq!(a.cofactor(0, 2), 210.0);
-            assert_eq!(a.cofactor(0, 3), 51.0);
-            assert_eq!(a.determinant(), -4071.0);
-        }
-
-        test("Testing matrix invertability") {
-            let invertable = Matrix4x4::new(
-                6.0, 4.0, 4.0, 4.0,
-                5.0, 5.0, 7.0, 6.0,
-                4.0, -9.0, 3.0, -7.0,
-                9.0, 1.0, 7.0, -6.0
-            );
-
-            assert_eq!(invertable.determinant(), -2120.0);
-            assert_eq!(invertable.is_invertable(), true);
-
-            let not_invertable = Matrix4x4::new(
-                -4.0, 2.0, -2.0, -3.0,
-                9.0, 6.0, 2.0, 6.0,
-                0.0, -5.0, 1.0, -5.0,
-                0.0, 0.0, 0.0, 0.0
-            );
-
-            assert_eq!(not_invertable.determinant(), 0.0);
-            assert_eq!(not_invertable.is_invertable(), false);
-        }
-
-        test("Calculate the inverse of a matrix") {
-            let a = Matrix4x4::new(
-                -5.0, 2.0, 6.0, -8.0,
-                1.0, -5.0, 1.0, 8.0,
-                7.0, 7.0, -6.0, -7.0,
-                1.0, -3.0, 7.0, 4.0
-            );
-
-            let mut b = a.inverse().unwrap();
-
-            assert_eq!(a.determinant(), 532.0);
-            assert_eq!(a.cofactor(2, 3), -160.0);
-            assert_eq!(b.at(3, 2), -160.0/532.0);
-            assert_eq!(a.cofactor(3, 2), 105.0);
-            assert_eq!(b.at(2, 3), 105.0/532.0);
-
-            let expected = Matrix4x4::new(
-                0.21805, 0.45113, 0.24060, -0.04511,
-                -0.80827, -1.45677, -0.44361, 0.52068,
-                -0.07895, -0.22368, -0.05263, 0.19737,
-                -0.52256, -0.81391, -0.30075, 0.30639
-            );
-
-            round_matrix(&mut b);
-            assert_eq!(b, expected);
-        }
-
-        test("Calculate the inverse of a second matrix") {
-            let a = Matrix4x4::new(
-                8.0, -5.0, 9.0, 2.0,
-                7.0, 5.0, 6.0, 1.0,
-                -6.0, 0.0, 9.0, 6.0,
-                -3.0, 0.0, -9.0, -4.0
-            );
-
-            let expected = Matrix4x4::new(
-                -0.15385, -0.15385, -0.28205, -0.53846,
-                -0.07692,  0.12308,  0.02564,  0.03077,
-                 0.35897,  0.35897,  0.43590,  0.92308,
-                -0.69231, -0.69231, -0.76923, -1.92308
-            );
-
-            let mut b = a.inverse().unwrap();
-            round_matrix(&mut b);
-
-            assert_eq!(b, expected);
-        }
-
-        test("Calculate the inverse of a third matrix") {
-            let a = Matrix4x4::new(
-                9.0,  3.0,  0.0,  9.0,
-                -5.0, -2.0, -6.0, -3.0,
-                -4.0,  9.0,  6.0,  4.0,
-                -7.0,  6.0,  6.0,  2.0,
-            );
-
-            let expected = Matrix4x4::new(
-                -0.04074, -0.07778,  0.14444, -0.22222 ,
-                -0.07778,  0.03333,  0.36667, -0.33333 ,
-                -0.02901, -0.14630, -0.10926,  0.12963 ,
-                0.17778,  0.06667, -0.26667,  0.33333
-            );
-
-            let mut b = a.inverse().unwrap();
-            round_matrix(&mut b);
-
-            assert_eq!(b, expected);
-        }
-
-        test("Multiplying a product by its invers") {
-            let a = Matrix4x4::new(
-                3.0, -9.0, 7.0, 3.0,
-                3.0, -8.0, 2.0, -9.0,
-                -4.0, 4.0, 4.0, 1.0,
-                -6.0, 5.0, -1.0, 1.0
-            );
-
-            let b = Matrix4x4::new(
-                8.0, 2.0, 2.0, 2.0,
-                3.0, -1.0, 7.0, 0.0,
-                7.0, 0.0, 5.0, 4.0,
-                6.0, -2.0, 0.0, 5.0
-            );
-
-            let c = a * b;
-            assert_eq!(c * b.inverse().unwrap(), a);
-        }
-
-        test("Multiplying by a translation matrix") {
-            let transform = Matrix4x4::translation(5.0, -3.0, 2.0);
-            let p = Tuple::point(-3.0, 4.0, 5.0);
-
-            assert_eq!(transform * p, Tuple::point(2.0, 1.0, 7.0));
-        }
-
-        test("Multiplying by the inverse of translation matrix") {
-            let transform = Matrix4x4::translation(5.0, -3.0, 2.0);
-            let p = Tuple::point(-3.0, 4.0, 5.0);
-            let inv = transform.inverse().unwrap();
-
-            assert_eq!(inv * p, Tuple::point(-8.0, 7.0, 3.0));
-        }
-
-        test("Translation does not affect vectors") {
-            let transform = Matrix4x4::translation(5.0, -3.0, 2.0);
-            let v = Tuple::vector(-3.0, 4.0, 5.0);
-
-            assert_eq!(transform * v, v);
-        }
-
-        test("apply a scaling matrix to a point") {
-            let transform = Matrix4x4::scaling(2.0, 3.0, 4.0);
-            let p = Tuple::point(-4.0, 6.0, 8.0);
-
-            assert_eq!(transform * p, Tuple::point(-8.0, 18.0, 32.0));
-        }
-
-        test("apply a scaling matrix to a vector") {
-            let transform = Matrix4x4::scaling(2.0, 3.0, 4.0);
-            let p = Tuple::vector(-4.0, 6.0, 8.0);
-
-            assert_eq!(transform * p, Tuple::vector(-8.0, 18.0, 32.0));
-        }
-
-        test("Multiply by the inverse of a scaling matrix") {
-            let transform = Matrix4x4::scaling(2.0, 3.0, 4.0);
-            let inv = transform.inverse().unwrap();
-            let v = Tuple::vector(-4.0, 6.0, 8.0);
-
-            assert_eq!(inv * v, Tuple::vector(-2.0, 2.0, 2.0));
-        }
-
-        test("reflection is scaling by a negative value") {
-            let transform = Matrix4x4::scaling(-1.0, 1.0, 1.0);
-            let p = Tuple::point(2.0, 3.0, 4.0);
-
-            assert_eq!(transform * p, Tuple::point(-2.0, 3.0, 4.0));
-        }
-
-        test("Rotating a point around the x axis") {
-            let p = Tuple::point(0.0, 1.0, 0.0);
-            let half_quarter = Matrix4x4::rotation_x(PI / 4.0);
-            let full_quarter = Matrix4x4::rotation_x(PI / 2.0);
-
-            assert_eq!(half_quarter * p, Tuple::point(0.0, 2f64.sqrt() / 2.0, 2f64.sqrt() / 2.0));
-            assert_eq!(full_quarter * p, Tuple::point(0.0, 0.0, 1.0));
-        }
-
-        test("Inverse of x rotation works in opposite direction") {
-            let p = Tuple::point(0.0, 1.0, 0.0);
-            let half_quarter = Matrix4x4::rotation_x(PI / 4.0);
-            let inverse = half_quarter.inverse().unwrap();
-
-            assert_eq!(inverse * p, Tuple::point(0.0, 2f64.sqrt() / 2.0, -2f64.sqrt() / 2.0));
-        }
-
-        test("Rotate around the y axis") {
-            let p = Tuple::point(0.0, 0.0, 1.0);
-            let half_quarter = Matrix4x4::rotation_y(PI / 4.0);
-            let full_quarter = Matrix4x4::rotation_y(PI / 2.0);
-
-            assert_eq!(half_quarter * p, Tuple::point(2f64.sqrt() / 2.0, 0.0, 2f64.sqrt() / 2.0));
-            assert_eq!(full_quarter * p, Tuple::point(1.0, 0.0, 0.0));
-        }
-
-        test("Rotate around the z axis") {
-            let p = Tuple::point(0.0, 1.0, 0.0);
-            let half_quarter = Matrix4x4::rotation_z(PI / 4.0);
-            let full_quarter = Matrix4x4::rotation_z(PI / 2.0);
-
-            assert_eq!(half_quarter * p, Tuple::point(-2f64.sqrt() / 2.0, 2f64.sqrt() / 2.0, 0.0));
-            assert_eq!(full_quarter * p, Tuple::point(-1.0, 0.0, 0.0));
-        }
-
-        test("A shearing transformation moves x in proportion to y") {
-            let transform = Matrix4x4::shearing(1.0, 0.0, 0.0, 0.0, 0.0, 0.0);
-            let p = Tuple::point(2.0, 3.0, 4.0);
-
-            assert_eq!(transform * p, Tuple::point(5.0, 3.0, 4.0));
-        }
-
-        test("Individual transformations are applied in sequence") {
-            let p = Tuple::point(1.0, 0.0, 1.0);
-            let A = Matrix4x4::rotation_x(std::f64::consts::PI / 2.0);
-            let B = Matrix4x4::scaling(5.0, 5.0, 5.0);
-            let C = Matrix4x4::translation(10.0, 5.0, 7.0);
-
-            let p2 = A * p;
-            assert_eq!(p2, Tuple::point(1.0, -1.0, 0.0));
-            let p3 = B * p2;
-            assert_eq!(p3, Tuple::point(5.0, -5.0, 0.0));
-            let p4 = C * p3;
-            assert_eq!(p4, Tuple::point(15.0, 0.0, 7.0));
-        }
-
-        test("Chained transformations must be applied in reverse order") {
-            let p = Tuple::point(1.0, 0.0, 1.0);
-            let A = Matrix4x4::rotation_x(std::f64::consts::PI / 2.0);
-            let B = Matrix4x4::scaling(5.0, 5.0, 5.0);
-            let C = Matrix4x4::translation(10.0, 5.0, 7.0);
-
-            let T = C * B * A;
-            assert_eq!(T * p, Tuple::point(15.0, 0.0, 7.0));
-        }
-
-        test("Chain transformation using fluent api") {
-            let p = Tuple::point(1.0, 0.0, 1.0);
-            let T = Matrix4x4::identity()
-                .translate(10.0, 5.0, 7.0)
-                .scale(5.0, 5.0, 5.0)
-                .rotate_x(std::f64::consts::PI / 2.0);
-            assert_eq!(T * p, Tuple::point(15.0, 0.0, 7.0));
+use super::{Matrix2x2, Matrix3x3, Matrix4x4, Tuple};
+use crate::maths::{Point, Vector};
+use std::f64::consts::PI;
+
+#[test]
+fn can_construct_a_matrix4x4() {
+    let m = Matrix4x4::new(
+        1.0, 2.0, 3.0, 4.0, 5.5, 6.5, 7.5, 8.5, 9.0, 10.0, 11.0, 12.0, 13.5, 14.5, 15.5, 16.5,
+    );
+
+    assert_eq!(m.at(0, 0), 1.0);
+    assert_eq!(m.at(0, 3), 4.0);
+    assert_eq!(m.at(1, 0), 5.5);
+}
+
+#[test]
+fn can_construct_a_2x2_matrix() {
+    let m = Matrix2x2::new(-3.0, 5.0, 1.0, -2.0);
+
+    assert_eq!(m.at(0, 0), -3.0);
+    assert_eq!(m.at(0, 1), 5.0);
+    assert_eq!(m.at(1, 0), 1.0);
+    assert_eq!(m.at(1, 1), -2.0);
+}
+
+#[test]
+fn can_construct_a_3x3_matrix() {
+    let m = Matrix3x3::new(-3.0, 5.0, 0.0, 1.0, -2.0, -7.0, 0.0, 1.0, 1.0);
+
+    assert_eq!(m.at(0, 0), -3.0);
+    assert_eq!(m.at(1, 1), -2.0);
+    assert_eq!(m.at(2, 2), 1.0);
+}
+
+#[test]
+fn we_can_test_the_equality_of_matrices() {
+    let a = Matrix4x4::new(
+        1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0,
+    );
+    let b = Matrix4x4::new(
+        1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0,
+    );
+
+    let c = Matrix4x4::new(
+        1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 8.0, 7.0, 6.0, 5.0, 4.0, 3.0, 2.0,
+    );
+
+    assert_eq!(a, b);
+
+    assert_ne!(a, c);
+}
+
+#[test]
+fn matrices_can_be_multiplied_together() {
+    let a = Matrix4x4::new(
+        1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 8.0, 7.0, 6.0, 5.0, 4.0, 3.0, 2.0,
+    );
+
+    let b = Matrix4x4::new(
+        -2.0, 1.0, 2.0, 3.0, 3.0, 2.0, 1.0, -1.0, 4.0, 3.0, 6.0, 5.0, 1.0, 2.0, 7.0, 8.0,
+    );
+
+    let expected = Matrix4x4::new(
+        20.0, 22.0, 50.0, 48.0, 44.0, 54.0, 114.0, 108.0, 40.0, 58.0, 110.0, 102.0, 16.0, 26.0,
+        46.0, 42.0,
+    );
+
+    assert_eq!(a * b, expected);
+}
+
+#[test]
+fn matrices_can_be_multiplied_by_a_tuple() {
+    let m = Matrix4x4::new(
+        1.0, 2.0, 3.0, 4.0, 2.0, 4.0, 4.0, 2.0, 8.0, 6.0, 4.0, 1.0, 0.0, 0.0, 0.0, 1.0,
+    );
+
+    let t = Tuple::new(1.0, 2.0, 3.0, 1.0);
+
+    assert_eq!(m * t, Tuple::new(18.0, 24.0, 33.0, 1.0));
+}
+
+#[test]
+fn multiplying_a_by_identity_returns_a() {
+    let a = Matrix4x4::new(
+        0.0, 1.0, 2.0, 4.0, 1.0, 2.0, 4.0, 8.0, 2.0, 4.0, 8.0, 16.0, 4.0, 8.0, 16.0, 32.0,
+    );
+
+    let id = Matrix4x4::identity();
+    assert_eq!(a * id, a);
+}
+
+#[test]
+fn matrices_can_be_transposed() {
+    let a = Matrix4x4::new(
+        0.0, 9.0, 3.0, 0.0, 9.0, 8.0, 0.0, 8.0, 1.0, 8.0, 5.0, 3.0, 0.0, 0.0, 5.0, 8.0,
+    );
+
+    let expected = Matrix4x4::new(
+        0.0, 9.0, 1.0, 0.0, 9.0, 8.0, 8.0, 0.0, 3.0, 0.0, 5.0, 5.0, 0.0, 8.0, 3.0, 8.0,
+    );
+
+    assert_eq!(a.transpose(), expected);
+}
+
+#[test]
+fn we_can_calculate_the_determinant_of_a_2x2_matrix() {
+    let m = Matrix2x2::new(1.0, 5.0, -3.0, 2.0);
+
+    assert_eq!(m.determinant(), 17.0);
+}
+
+#[test]
+fn create_a_submatrix_from_a_3x3_matrix() {
+    let m = Matrix3x3::new(1.0, 5.0, 0.0, -3.0, 2.0, 7.0, 0.0, 6.0, -3.0);
+
+    let result = Matrix2x2::new(-3.0, 2.0, 0.0, 6.0);
+
+    assert_eq!(m.submatrix(0, 2), result);
+}
+
+#[test]
+fn get_the_minor_of_a_matrix3x3() {
+    let a = Matrix3x3::new(3.0, 5.0, 0.0, 2.0, -1.0, -7.0, 6.0, -1.0, 5.0);
+
+    let b = a.submatrix(1, 0);
+    assert_eq!(b.determinant(), 25.0);
+    assert_eq!(a.minor(1, 0), 25.0);
+}
+
+#[test]
+fn calculate_the_cofactor_of_a_3x3_matrix() {
+    let a = Matrix3x3::new(3.0, 5.0, 0.0, 2.0, -1.0, -7.0, 6.0, -1.0, 5.0);
+
+    assert_eq!(a.minor(0, 0), -12.0);
+    assert_eq!(a.cofactor(0, 0), -12.0);
+    assert_eq!(a.minor(1, 0), 25.0);
+    assert_eq!(a.cofactor(1, 0), -25.0);
+}
+
+#[test]
+fn calculate_the_determinant_of_a_3x3_matrix() {
+    let a = Matrix3x3::new(1.0, 2.0, 6.0, -5.0, 8.0, -4.0, 2.0, 6.0, 4.0);
+
+    assert_eq!(a.cofactor(0, 0), 56.0);
+    assert_eq!(a.cofactor(0, 1), 12.0);
+    assert_eq!(a.cofactor(0, 2), -46.0);
+    assert_eq!(a.determinant(), -196.0);
+}
+
+#[test]
+fn calculate_the_determinant_of_a_4x4_matrix() {
+    let a = Matrix4x4::new(
+        -2.0, -8.0, 3.0, 5.0, -3.0, 1.0, 7.0, 3.0, 1.0, 2.0, -9.0, 6.0, -6.0, 7.0, 7.0, -9.0,
+    );
+
+    assert_eq!(a.cofactor(0, 0), 690.0);
+    assert_eq!(a.cofactor(0, 1), 447.0);
+    assert_eq!(a.cofactor(0, 2), 210.0);
+    assert_eq!(a.cofactor(0, 3), 51.0);
+    assert_eq!(a.determinant(), -4071.0);
+}
+
+#[test]
+fn testing_matrix_invertability() {
+    let invertable = Matrix4x4::new(
+        6.0, 4.0, 4.0, 4.0, 5.0, 5.0, 7.0, 6.0, 4.0, -9.0, 3.0, -7.0, 9.0, 1.0, 7.0, -6.0,
+    );
+
+    assert_eq!(invertable.determinant(), -2120.0);
+    assert_eq!(invertable.is_invertable(), true);
+
+    let not_invertable = Matrix4x4::new(
+        -4.0, 2.0, -2.0, -3.0, 9.0, 6.0, 2.0, 6.0, 0.0, -5.0, 1.0, -5.0, 0.0, 0.0, 0.0, 0.0,
+    );
+
+    assert_eq!(not_invertable.determinant(), 0.0);
+    assert_eq!(not_invertable.is_invertable(), false);
+}
+
+#[test]
+fn calculate_the_inverse_of_a_matrix() {
+    let a = Matrix4x4::new(
+        -5.0, 2.0, 6.0, -8.0, 1.0, -5.0, 1.0, 8.0, 7.0, 7.0, -6.0, -7.0, 1.0, -3.0, 7.0, 4.0,
+    );
+
+    let mut b = a.inverse().unwrap();
+
+    assert_eq!(a.determinant(), 532.0);
+    assert_eq!(a.cofactor(2, 3), -160.0);
+    assert_eq!(b.at(3, 2), -160.0 / 532.0);
+    assert_eq!(a.cofactor(3, 2), 105.0);
+    assert_eq!(b.at(2, 3), 105.0 / 532.0);
+
+    let expected = Matrix4x4::new(
+        0.21805, 0.45113, 0.24060, -0.04511, -0.80827, -1.45677, -0.44361, 0.52068, -0.07895,
+        -0.22368, -0.05263, 0.19737, -0.52256, -0.81391, -0.30075, 0.30639,
+    );
+
+    round_matrix(&mut b);
+    assert_eq!(b, expected);
+}
+
+#[test]
+fn calculate_the_inverse_of_a_second_matrix() {
+    let a = Matrix4x4::new(
+        8.0, -5.0, 9.0, 2.0, 7.0, 5.0, 6.0, 1.0, -6.0, 0.0, 9.0, 6.0, -3.0, 0.0, -9.0, -4.0,
+    );
+
+    let expected = Matrix4x4::new(
+        -0.15385, -0.15385, -0.28205, -0.53846, -0.07692, 0.12308, 0.02564, 0.03077, 0.35897,
+        0.35897, 0.43590, 0.92308, -0.69231, -0.69231, -0.76923, -1.92308,
+    );
+
+    let mut b = a.inverse().unwrap();
+    round_matrix(&mut b);
+
+    assert_eq!(b, expected);
+}
+
+#[test]
+fn calculate_the_inverse_of_a_third_matrix() {
+    let a = Matrix4x4::new(
+        9.0, 3.0, 0.0, 9.0, -5.0, -2.0, -6.0, -3.0, -4.0, 9.0, 6.0, 4.0, -7.0, 6.0, 6.0, 2.0,
+    );
+
+    let expected = Matrix4x4::new(
+        -0.04074, -0.07778, 0.14444, -0.22222, -0.07778, 0.03333, 0.36667, -0.33333, -0.02901,
+        -0.14630, -0.10926, 0.12963, 0.17778, 0.06667, -0.26667, 0.33333,
+    );
+
+    let mut b = a.inverse().unwrap();
+    round_matrix(&mut b);
+
+    assert_eq!(b, expected);
+}
+
+#[test]
+fn multiplying_a_product_by_its_invers() {
+    let a = Matrix4x4::new(
+        3.0, -9.0, 7.0, 3.0, 3.0, -8.0, 2.0, -9.0, -4.0, 4.0, 4.0, 1.0, -6.0, 5.0, -1.0, 1.0,
+    );
+
+    let b = Matrix4x4::new(
+        8.0, 2.0, 2.0, 2.0, 3.0, -1.0, 7.0, 0.0, 7.0, 0.0, 5.0, 4.0, 6.0, -2.0, 0.0, 5.0,
+    );
+
+    let c = a * b;
+    assert_eq!(c * b.inverse().unwrap(), a);
+}
+
+#[test]
+fn multiplying_by_a_translation_matrix() {
+    let transform = Matrix4x4::translation(5.0, -3.0, 2.0);
+    let p = Tuple::point(-3.0, 4.0, 5.0);
+
+    assert_eq!(transform * p, Tuple::point(2.0, 1.0, 7.0));
+}
+
+#[test]
+fn multiplying_by_the_inverse_of_translation_matrix() {
+    let transform = Matrix4x4::translation(5.0, -3.0, 2.0);
+    let p = Tuple::point(-3.0, 4.0, 5.0);
+    let inv = transform.inverse().unwrap();
+
+    assert_eq!(inv * p, Tuple::point(-8.0, 7.0, 3.0));
+}
+
+#[test]
+fn translation_does_not_affect_vectors() {
+    let transform = Matrix4x4::translation(5.0, -3.0, 2.0);
+    let v = Tuple::vector(-3.0, 4.0, 5.0);
+
+    assert_eq!(transform * v, v);
+}
+
+#[test]
+fn apply_a_scaling_matrix_to_a_point() {
+    let transform = Matrix4x4::scaling(2.0, 3.0, 4.0);
+    let p = Tuple::point(-4.0, 6.0, 8.0);
+
+    assert_eq!(transform * p, Tuple::point(-8.0, 18.0, 32.0));
+}
+
+#[test]
+fn apply_a_scaling_matrix_to_a_vector() {
+    let transform = Matrix4x4::scaling(2.0, 3.0, 4.0);
+    let p = Tuple::vector(-4.0, 6.0, 8.0);
+
+    assert_eq!(transform * p, Tuple::vector(-8.0, 18.0, 32.0));
+}
+
+#[test]
+fn multiply_by_the_inverse_of_a_scaling_matrix() {
+    let transform = Matrix4x4::scaling(2.0, 3.0, 4.0);
+    let inv = transform.inverse().unwrap();
+    let v = Tuple::vector(-4.0, 6.0, 8.0);
+
+    assert_eq!(inv * v, Tuple::vector(-2.0, 2.0, 2.0));
+}
+
+#[test]
+fn reflection_is_scaling_by_a_negative_value() {
+    let transform = Matrix4x4::scaling(-1.0, 1.0, 1.0);
+    let p = Tuple::point(2.0, 3.0, 4.0);
+
+    assert_eq!(transform * p, Tuple::point(-2.0, 3.0, 4.0));
+}
+
+#[test]
+fn rotating_a_point_around_the_x_axis() {
+    let p = Tuple::point(0.0, 1.0, 0.0);
+    let half_quarter = Matrix4x4::rotation_x(PI / 4.0);
+    let full_quarter = Matrix4x4::rotation_x(PI / 2.0);
+
+    assert_eq!(
+        half_quarter * p,
+        Tuple::point(0.0, 2f64.sqrt() / 2.0, 2f64.sqrt() / 2.0)
+    );
+    assert_eq!(full_quarter * p, Tuple::point(0.0, 0.0, 1.0));
+}
+
+#[test]
+fn inverse_of_x_rotation_works_in_opposite_direction() {
+    let p = Tuple::point(0.0, 1.0, 0.0);
+    let half_quarter = Matrix4x4::rotation_x(PI / 4.0);
+    let inverse = half_quarter.inverse().unwrap();
+
+    assert_eq!(
+        inverse * p,
+        Tuple::point(0.0, 2f64.sqrt() / 2.0, -2f64.sqrt() / 2.0)
+    );
+}
+
+#[test]
+fn rotate_around_the_y_axis() {
+    let p = Tuple::point(0.0, 0.0, 1.0);
+    let half_quarter = Matrix4x4::rotation_y(PI / 4.0);
+    let full_quarter = Matrix4x4::rotation_y(PI / 2.0);
+
+    assert_eq!(
+        half_quarter * p,
+        Tuple::point(2f64.sqrt() / 2.0, 0.0, 2f64.sqrt() / 2.0)
+    );
+    assert_eq!(full_quarter * p, Tuple::point(1.0, 0.0, 0.0));
+}
+
+#[test]
+fn rotate_around_the_z_axis() {
+    let p = Tuple::point(0.0, 1.0, 0.0);
+    let half_quarter = Matrix4x4::rotation_z(PI / 4.0);
+    let full_quarter = Matrix4x4::rotation_z(PI / 2.0);
+
+    assert_eq!(
+        half_quarter * p,
+        Tuple::point(-2f64.sqrt() / 2.0, 2f64.sqrt() / 2.0, 0.0)
+    );
+    assert_eq!(full_quarter * p, Tuple::point(-1.0, 0.0, 0.0));
+}
+
+#[test]
+fn a_shearing_transformation_moves_x_in_proportion_to_y() {
+    let transform = Matrix4x4::shearing(1.0, 0.0, 0.0, 0.0, 0.0, 0.0);
+    let p = Tuple::point(2.0, 3.0, 4.0);
+
+    assert_eq!(transform * p, Tuple::point(5.0, 3.0, 4.0));
+}
+
+#[test]
+fn individual_transformations_are_applied_in_sequence() {
+    let p = Tuple::point(1.0, 0.0, 1.0);
+    let A = Matrix4x4::rotation_x(std::f64::consts::PI / 2.0);
+    let B = Matrix4x4::scaling(5.0, 5.0, 5.0);
+    let C = Matrix4x4::translation(10.0, 5.0, 7.0);
+
+    let p2 = A * p;
+    assert_eq!(p2, Tuple::point(1.0, -1.0, 0.0));
+    let p3 = B * p2;
+    assert_eq!(p3, Tuple::point(5.0, -5.0, 0.0));
+    let p4 = C * p3;
+    assert_eq!(p4, Tuple::point(15.0, 0.0, 7.0));
+}
+
+#[test]
+fn chained_transformations_must_be_applied_in_reverse_order() {
+    let p = Tuple::point(1.0, 0.0, 1.0);
+    let A = Matrix4x4::rotation_x(std::f64::consts::PI / 2.0);
+    let B = Matrix4x4::scaling(5.0, 5.0, 5.0);
+    let C = Matrix4x4::translation(10.0, 5.0, 7.0);
+
+    let T = C * B * A;
+    assert_eq!(T * p, Tuple::point(15.0, 0.0, 7.0));
+}
+
+#[test]
+fn chain_transformation_using_fluent_api() {
+    let p = Tuple::point(1.0, 0.0, 1.0);
+    let t = Matrix4x4::identity()
+        .translate(10.0, 5.0, 7.0)
+        .scale(5.0, 5.0, 5.0)
+        .rotate_x(std::f64::consts::PI / 2.0);
+    assert_eq!(t * p, Tuple::point(15.0, 0.0, 7.0));
+}
+
+fn round_matrix(matrix: &mut Matrix4x4) {
+    let round = |val: f64| (val * 100000.0).round() / 100000.0;
+
+    for row in 0..4 {
+        for col in 0..4 {
+            matrix.set_at(row, col, round(matrix.at(row, col)));
         }
     }
+}
 
-    fn round_matrix(matrix: &mut Matrix4x4) {
-        let round = |val: f64| (val * 100000.0).round() / 100000.0;
+#[test]
+fn the_transformation_matrix_for_the_default_orientation() {
+    let from = Point::new(0.0, 0.0, 0.0);
+    let to = Point::new(0.0, 0.0, -1.0);
+    let up = Vector::up();
 
-        for row in 0..4 {
-            for col in 0..4 {
-                matrix.set_at(row, col, round(matrix.at(row, col)));
-            }
-        }
-    }
+    let view = Matrix4x4::view(from, to, up);
+    assert_eq!(view, Matrix4x4::identity());
+}
 
-    #[test]
-    fn the_transformation_matrix_for_the_default_orientation() {
-        let from = Point::new(0.0, 0.0, 0.0);
-        let to = Point::new(0.0, 0.0, -1.0);
-        let up = Vector::up();
+#[test]
+fn a_view_transformation_matrix_looking_in_positive_z_direction() {
+    let from = Point::new(0.0, 0.0, 0.0);
+    let to = Point::new(0.0, 0.0, 1.0);
+    let up = Vector::up();
 
-        let view = Matrix4x4::view(from, to, up);
-        assert_eq!(view, Matrix4x4::identity());
-    }
+    let view = Matrix4x4::view(from, to, up);
+    assert_eq!(view, Matrix4x4::scaling(-1.0, 1.0, -1.0));
+}
 
-    #[test]
-    fn a_view_transformation_matrix_looking_in_positive_z_direction() {
-        let from = Point::new(0.0, 0.0, 0.0);
-        let to = Point::new(0.0, 0.0, 1.0);
-        let up = Vector::up();
+#[test]
+fn the_view_transformation_moves_the_world() {
+    let from = Point::new(0.0, 0.0, 8.0);
+    let to = Point::new(0.0, 0.0, 0.0);
+    let up = Vector::up();
 
-        let view = Matrix4x4::view(from, to, up);
-        assert_eq!(view, Matrix4x4::scaling(-1.0, 1.0, -1.0));
-    }
-
-    #[test]
-    fn the_view_transformation_moves_the_world() {
-        let from = Point::new(0.0, 0.0, 8.0);
-        let to = Point::new(0.0, 0.0, 0.0);
-        let up = Vector::up();
-
-        let view = Matrix4x4::view(from, to, up);
-        assert_eq!(view, Matrix4x4::translation(0.0, 0.0, -8.0));
-    }
+    let view = Matrix4x4::view(from, to, up);
+    assert_eq!(view, Matrix4x4::translation(0.0, 0.0, -8.0));
 }

--- a/src/maths/mod.rs
+++ b/src/maths/mod.rs
@@ -21,5 +21,7 @@ pub use tuple::Tuple;
 pub use vector::Vector;
 
 // Tests
+#[cfg(test)]
 mod matrix_test;
+#[cfg(test)]
 mod tuple_test;

--- a/src/maths/tuple_test.rs
+++ b/src/maths/tuple_test.rs
@@ -1,160 +1,179 @@
-#[cfg(test)]
-mod tuple_test {
-    use super::super::point::Point;
-    use super::super::vector::Vector;
-    use super::super::Tuple;
-    use rust_catch::tests;
 
-    tests! {
-        test("can create a tuple and get its values") {
-            let t = Tuple::new(1.0, 2.0, 3.0, 4.0);
-            assert_eq!(t.x(), 1.0);
-            assert_eq!(t.y(), 2.0);
-            assert_eq!(t.z(), 3.0);
-            assert_eq!(t.w(), 4.0);
-        }
+use super::point::Point;
+use super::vector::Vector;
+use super::Tuple;
 
-        test("tuple with w 1 is a vector") {
-            let t = Tuple::new(1.0, 2.0, 3.0, 0.0);
-            assert_eq!(t.is_vector(), true);
-            assert_eq!(t.is_point(), false);
-        }
+#[test]
+fn can_create_a_tuple_and_get_its_values() {
+    let t = Tuple::new(1.0, 2.0, 3.0, 4.0);
+    assert_eq!(t.x(), 1.0);
+    assert_eq!(t.y(), 2.0);
+    assert_eq!(t.z(), 3.0);
+    assert_eq!(t.w(), 4.0);
+}
 
-        test("tuple with w 0 is a point") {
-            let t = Tuple::new(1.0, 2.0, 3.0, 1.0);
-            assert_eq!(t.is_point(), true);
-            assert_eq!(t.is_vector(), false);
-        }
+#[test]
+fn tuple_with_w_1_is_a_vector() {
+    let t = Tuple::new(1.0, 2.0, 3.0, 0.0);
+    assert_eq!(t.is_vector(), true);
+    assert_eq!(t.is_point(), false);
+}
 
-        test("point creates a tuple with w 1") {
-            let p = Point::new(1.0, 2.0, 3.0);
-            assert_eq!(p.w(), 1.0);
-        }
+#[test]
+fn tuple_with_w_0_is_a_point() {
+    let t = Tuple::new(1.0, 2.0, 3.0, 1.0);
+    assert_eq!(t.is_point(), true);
+    assert_eq!(t.is_vector(), false);
+}
 
-        test("vector create a tuple with w 0") {
-            let v = Vector::new(1.0, 2.0, 3.0);
-            assert_eq!(v.w(), 0.0);
-        }
+#[test]
+fn point_creates_a_tuple_with_w_1() {
+    let p = Point::new(1.0, 2.0, 3.0);
+    assert_eq!(p.w(), 1.0);
+}
 
-        test("tuples compare correctly") {
-            let a = Tuple::new(1.0, 2.0, 3.0, 0.0);
-            let b = Tuple::new(1.0, 2.0, 3.0, 0.0);
+#[test]
+fn vector_create_a_tuple_with_w_0() {
+    let v = Vector::new(1.0, 2.0, 3.0);
+    assert_eq!(v.w(), 0.0);
+}
 
-            assert_eq!(a, b);
-        }
+#[test]
+fn tuples_compare_correctly() {
+    let a = Tuple::new(1.0, 2.0, 3.0, 0.0);
+    let b = Tuple::new(1.0, 2.0, 3.0, 0.0);
 
-        test("adding tuples works") {
-            let a = Tuple::new(3.0, -2.0, 5.0, 1.0);
-            let b = Tuple::new(-2.0, 3.0, 1.0, 0.0);
+    assert_eq!(a, b);
+}
 
-            assert_eq!(a + b, Tuple::new(1.0, 1.0, 6.0, 1.0));
-        }
+#[test]
+fn adding_tuples_works() {
+    let a = Tuple::new(3.0, -2.0, 5.0, 1.0);
+    let b = Tuple::new(-2.0, 3.0, 1.0, 0.0);
 
-        test("subtracting 2 points") {
-            let p1 = Point::new(3.0, 2.0, 1.0);
-            let p2 = Point::new(5.0, 6.0, 7.0);
+    assert_eq!(a + b, Tuple::new(1.0, 1.0, 6.0, 1.0));
+}
 
-            assert_eq!(p1 - p2, Vector::new(-2.0, -4.0, -6.0));
-        }
+#[test]
+fn subtracting_2_points() {
+    let p1 = Point::new(3.0, 2.0, 1.0);
+    let p2 = Point::new(5.0, 6.0, 7.0);
 
-        test("subtracting 2 actual points") {
-            let p1 = Point::new(3.0, 2.0, 1.0);
-            let p2 = Point::new(5.0, 6.0, 7.0);
+    assert_eq!(p1 - p2, Vector::new(-2.0, -4.0, -6.0));
+}
 
-            assert_eq!(p1 - p2, Vector::new(-2.0, -4.0, -6.0));
-        }
+#[test]
+fn subtracting_2_actual_points() {
+    let p1 = Point::new(3.0, 2.0, 1.0);
+    let p2 = Point::new(5.0, 6.0, 7.0);
 
-        test("subtracting a vector from a point") {
-            let p = Tuple::point(3.0, 2.0, 1.0);
-            let v = Tuple::vector(5.0, 6.0, 7.0);
+    assert_eq!(p1 - p2, Vector::new(-2.0, -4.0, -6.0));
+}
 
-            assert_eq!(p - v, Tuple::point(-2.0, -4.0, -6.0));
-        }
+#[test]
+fn subtracting_a_vector_from_a_point() {
+    let p = Tuple::point(3.0, 2.0, 1.0);
+    let v = Tuple::vector(5.0, 6.0, 7.0);
 
-        test("subtracting a real vector from a real point") {
-            let p = Point::new(3.0, 2.0, 1.0);
-            let v = Vector::new(5.0, 6.0, 7.0);
+    assert_eq!(p - v, Tuple::point(-2.0, -4.0, -6.0));
+}
 
-            assert_eq!(p - v, Point::new(-2.0, -4.0, -6.0));
-        }
+#[test]
+fn subtracting_a_real_vector_from_a_real_point() {
+    let p = Point::new(3.0, 2.0, 1.0);
+    let v = Vector::new(5.0, 6.0, 7.0);
 
-        test("subtracting 2 vectors") {
-            let v1 = Tuple::vector(3.0, 2.0, 1.0);
-            let v2 = Tuple::vector(5.0, 6.0, 7.0);
+    assert_eq!(p - v, Point::new(-2.0, -4.0, -6.0));
+}
 
-            assert_eq!(v1 - v2, Tuple::vector(-2.0, -4.0, -6.0));
-        }
+#[test]
+fn subtracting_2_vectors() {
+    let v1 = Tuple::vector(3.0, 2.0, 1.0);
+    let v2 = Tuple::vector(5.0, 6.0, 7.0);
 
-        test("subtracting 2 actual vectors") {
-            let v1 = Vector::new(3.0, 2.0, 1.0);
-            let v2 = Vector::new(5.0, 6.0, 7.0);
+    assert_eq!(v1 - v2, Tuple::vector(-2.0, -4.0, -6.0));
+}
 
-            assert_eq!(v1 - v2, Vector::new(-2.0, -4.0, -6.0));
-        }
+#[test]
+fn subtracting_2_actual_vectors() {
+    let v1 = Vector::new(3.0, 2.0, 1.0);
+    let v2 = Vector::new(5.0, 6.0, 7.0);
 
-        test("tuples can be negated") {
-            let a = Tuple::new(1.0, -2.0, 3.0, -4.0);
-            assert_eq!(-a, Tuple::new(-1.0, 2.0, -3.0, 4.0));
-        }
+    assert_eq!(v1 - v2, Vector::new(-2.0, -4.0, -6.0));
+}
 
-        test("Tuple can be multiplied by a scaler") {
-            let a = Tuple::new(1.0, -2.0, 3.0, -4.0);
-            assert_eq!(a * 3.5, Tuple::new(3.5, -7.0, 10.5, -14.0));
-        }
+#[test]
+fn tuples_can_be_negated() {
+    let a = Tuple::new(1.0, -2.0, 3.0, -4.0);
+    assert_eq!(-a, Tuple::new(-1.0, 2.0, -3.0, 4.0));
+}
 
-        test("Tuple can be divided by a scaler") {
-            let a = Tuple::new(1.0, -2.0, 3.0, -4.0);
-            assert_eq!(a / 2.0, Tuple::new(0.5, -1.0, 1.5, -2.0));
-        }
+#[test]
+fn tuple_can_be_multiplied_by_a_scaler() {
+    let a = Tuple::new(1.0, -2.0, 3.0, -4.0);
+    assert_eq!(a * 3.5, Tuple::new(3.5, -7.0, 10.5, -14.0));
+}
 
-        test("Compute the length of a vector") {
-            let v = Vector::new(1.0, 0.0, 0.0);
-            assert_eq!(v.len(), 1.0);
-        }
+#[test]
+fn tuple_can_be_divided_by_a_scaler() {
+    let a = Tuple::new(1.0, -2.0, 3.0, -4.0);
+    assert_eq!(a / 2.0, Tuple::new(0.5, -1.0, 1.5, -2.0));
+}
 
-        test("Compute the length of a different vector") {
-            let v = Vector::new(1.0, 2.0, 3.0);
-            assert_eq!(v.len(), f64::sqrt(14.0));
-        }
+#[test]
+fn compute_the_length_of_a_vector() {
+    let v = Vector::new(1.0, 0.0, 0.0);
+    assert_eq!(v.len(), 1.0);
+}
 
-        test("normalize vector 4_0_0 gives 1_0_0") {
-            let v = Vector::new(4.0, 0.0, 0.0);
-            assert_eq!(v.normalize(), Vector::new(1.0, 0.0, 0.0));
-        }
+#[test]
+fn compute_the_length_of_a_different_vector() {
+    let v = Vector::new(1.0, 2.0, 3.0);
+    assert_eq!(v.len(), f64::sqrt(14.0));
+}
 
-        test("Compute the dot product of 2 vectors") {
-            let v1 = Vector::new(1.0, 2.0, 3.0);
-            let v2 = Vector::new(2.0, 3.0, 4.0);
-            assert_eq!(Vector::dot(v1, v2), 20.0);
-        }
+#[test]
+fn normalize_vector_4_0_0_gives_1_0_0() {
+    let v = Vector::new(4.0, 0.0, 0.0);
+    assert_eq!(v.normalize(), Vector::new(1.0, 0.0, 0.0));
+}
 
-        test("Compute the cross product of 2 vectors") {
-            let v1 = Vector::new(1.0, 2.0, 3.0);
-            let v2 = Vector::new(2.0, 3.0, 4.0);
-            assert_eq!(Vector::cross(v1, v2), Vector::new(-1.0, 2.0, -1.0));
-            assert_eq!(Vector::cross(v2, v1), Vector::new(1.0, -2.0, 1.0));
-        }
+#[test]
+fn compute_the_dot_product_of_2_vectors() {
+    let v1 = Vector::new(1.0, 2.0, 3.0);
+    let v2 = Vector::new(2.0, 3.0, 4.0);
+    assert_eq!(Vector::dot(v1, v2), 20.0);
+}
 
-        test("Reflecting a vector approaching at 45") {
-            let v = Vector::new(1.0, -1.0, 0.0);
-            let n = Vector::new(0.0, 1.0, 0.0);
+#[test]
+fn compute_the_cross_product_of_2_vectors() {
+    let v1 = Vector::new(1.0, 2.0, 3.0);
+    let v2 = Vector::new(2.0, 3.0, 4.0);
+    assert_eq!(Vector::cross(v1, v2), Vector::new(-1.0, 2.0, -1.0));
+    assert_eq!(Vector::cross(v2, v1), Vector::new(1.0, -2.0, 1.0));
+}
 
-            assert_eq!(v.reflect(n), Vector::new(1.0, 1.0, 0.0));
-        }
+#[test]
+fn reflecting_a_vector_approaching_at_45() {
+    let v = Vector::new(1.0, -1.0, 0.0);
+    let n = Vector::new(0.0, 1.0, 0.0);
 
-        test("Reflecting a vector off a slanted surface") {
-            let v = Vector::new(0.0, -1.0, 0.0);
-            let fraq = 2f64.sqrt() / 2.0;
-            let n = Vector::new(fraq, fraq, 0.0);
+    assert_eq!(v.reflect(n), Vector::new(1.0, 1.0, 0.0));
+}
 
-            let r = v.reflect(n);
-            assert_eq!(r, Vector::new(1.0, 0.0, 0.0));
-        }
+#[test]
+fn reflecting_a_vector_off_a_slanted_surface() {
+    let v = Vector::new(0.0, -1.0, 0.0);
+    let fraq = 2f64.sqrt() / 2.0;
+    let n = Vector::new(fraq, fraq, 0.0);
 
-        test("Can negate a vector") {
-            let v = Vector::new(1.0, -2.0, 3.0);
+    let r = v.reflect(n);
+    assert_eq!(r, Vector::new(1.0, 0.0, 0.0));
+}
 
-            assert_eq!(-v, Vector::new(-1.0, 2.0, -3.0));
-        }
-    }
+#[test]
+fn can_negate_a_vector() {
+    let v = Vector::new(1.0, -2.0, 3.0);
+
+    assert_eq!(-v, Vector::new(-1.0, 2.0, -3.0));
 }

--- a/src/primitives/camera.rs
+++ b/src/primitives/camera.rs
@@ -1,9 +1,6 @@
-use super::{world::WorldImpl, Ray, World};
-use crate::{
-    canvas::{Canvas, Color},
-    maths::{is_same, round, Matrix4x4, Point, Vector},
-};
-use std::f64::consts::FRAC_PI_2;
+use super::{world::WorldImpl, Ray};
+use crate::canvas::{Canvas, Color};
+use crate::maths::{Matrix4x4, Point};
 
 use rayon::prelude::*;
 
@@ -116,77 +113,4 @@ impl Camera {
 
         image
     }
-}
-
-#[test]
-fn constructing_a_camera() {
-    let width = 160;
-    let height = 120;
-    let fov = FRAC_PI_2;
-    let camera = Camera::new(width, height, fov, Matrix4x4::identity());
-
-    assert_eq!(camera.width(), width);
-    assert_eq!(camera.height(), height);
-    assert_eq!(camera.fov(), fov);
-    assert_eq!(camera.transform(), Matrix4x4::identity());
-}
-
-#[test]
-fn the_pixel_size_for_a_canvas() {
-    let c1 = Camera::new(200, 125, FRAC_PI_2, Matrix4x4::identity());
-    assert!(is_same(c1.pixel_size(), 0.01));
-
-    let c2 = Camera::new(125, 200, FRAC_PI_2, Matrix4x4::identity());
-    assert!(is_same(c2.pixel_size(), 0.01));
-}
-
-#[test]
-fn constructing_a_ray_through_the_center_of_the_canvas() {
-    let c = Camera::new(201, 101, FRAC_PI_2, Matrix4x4::identity());
-    let r = c.ray_for_pixel(100, 50);
-    assert_eq!(r.origin(), Point::new(0.0, 0.0, 0.0));
-    assert_eq!(r.direction(), Vector::new(0.0, 0.0, -1.0));
-}
-
-#[test]
-fn constructing_a_ray_through_a_corner_of_the_canvas() {
-    let c = Camera::new(201, 101, FRAC_PI_2, Matrix4x4::identity());
-    let r = c.ray_for_pixel(0, 0);
-
-    let direction = r.direction();
-    assert_eq!(r.origin(), Point::new(0.0, 0.0, 0.0));
-    assert_eq!(round(direction.x()), 0.66519);
-    assert_eq!(round(direction.y()), 0.33259);
-    assert_eq!(round(direction.z()), -0.66851);
-}
-
-#[test]
-fn constructing_a_ray_when_the_camera_is_transformed() {
-    let camera_translation =
-        Matrix4x4::rotation_y(std::f64::consts::FRAC_PI_4).translate(0.0, -2.0, 5.0);
-    let c = Camera::new(201, 101, FRAC_PI_2, camera_translation);
-    let r = c.ray_for_pixel(100, 50);
-    assert_eq!(r.origin(), Point::new(0.0, 2.0, -5.0));
-    assert_eq!(
-        r.direction(),
-        Vector::new(2f64.sqrt() / 2.0, 0.0, -2f64.sqrt() / 2.0)
-    );
-}
-
-#[test]
-fn rendering_a_world_with_a_camera() {
-    let w = World::default().generate();
-    let view_transform = Matrix4x4::view(
-        Point::new(0.0, 0.0, -5.0),
-        Point::new(0.0, 0.0, 0.0),
-        Vector::up(),
-    );
-    let c = Camera::new(11, 11, FRAC_PI_2, view_transform);
-
-    let image = c.render(w);
-    let color = image.pixel_at(5, 5);
-
-    assert_eq!(round(color.r()), 0.38066);
-    assert_eq!(round(color.g()), 0.47583);
-    assert_eq!(round(color.b()), 0.28550);
 }

--- a/src/primitives/camera_test.rs
+++ b/src/primitives/camera_test.rs
@@ -1,0 +1,76 @@
+use super::{Camera, World};
+use crate::maths::{is_same, round, Matrix4x4, Point, Vector};
+use std::f64::consts::FRAC_PI_2;
+
+#[test]
+fn constructing_a_camera() {
+    let width = 160;
+    let height = 120;
+    let fov = FRAC_PI_2;
+    let camera = Camera::new(width, height, fov, Matrix4x4::identity());
+
+    assert_eq!(camera.width(), width);
+    assert_eq!(camera.height(), height);
+    assert_eq!(camera.fov(), fov);
+    assert_eq!(camera.transform(), Matrix4x4::identity());
+}
+
+#[test]
+fn the_pixel_size_for_a_canvas() {
+    let c1 = Camera::new(200, 125, FRAC_PI_2, Matrix4x4::identity());
+    assert!(is_same(c1.pixel_size(), 0.01));
+
+    let c2 = Camera::new(125, 200, FRAC_PI_2, Matrix4x4::identity());
+    assert!(is_same(c2.pixel_size(), 0.01));
+}
+
+#[test]
+fn constructing_a_ray_through_the_center_of_the_canvas() {
+    let c = Camera::new(201, 101, FRAC_PI_2, Matrix4x4::identity());
+    let r = c.ray_for_pixel(100, 50);
+    assert_eq!(r.origin(), Point::new(0.0, 0.0, 0.0));
+    assert_eq!(r.direction(), Vector::new(0.0, 0.0, -1.0));
+}
+
+#[test]
+fn constructing_a_ray_through_a_corner_of_the_canvas() {
+    let c = Camera::new(201, 101, FRAC_PI_2, Matrix4x4::identity());
+    let r = c.ray_for_pixel(0, 0);
+
+    let direction = r.direction();
+    assert_eq!(r.origin(), Point::new(0.0, 0.0, 0.0));
+    assert_eq!(round(direction.x()), 0.66519);
+    assert_eq!(round(direction.y()), 0.33259);
+    assert_eq!(round(direction.z()), -0.66851);
+}
+
+#[test]
+fn constructing_a_ray_when_the_camera_is_transformed() {
+    let camera_translation =
+        Matrix4x4::rotation_y(std::f64::consts::FRAC_PI_4).translate(0.0, -2.0, 5.0);
+    let c = Camera::new(201, 101, FRAC_PI_2, camera_translation);
+    let r = c.ray_for_pixel(100, 50);
+    assert_eq!(r.origin(), Point::new(0.0, 2.0, -5.0));
+    assert_eq!(
+        r.direction(),
+        Vector::new(2f64.sqrt() / 2.0, 0.0, -2f64.sqrt() / 2.0)
+    );
+}
+
+#[test]
+fn rendering_a_world_with_a_camera() {
+    let w = World::default().generate();
+    let view_transform = Matrix4x4::view(
+        Point::new(0.0, 0.0, -5.0),
+        Point::new(0.0, 0.0, 0.0),
+        Vector::up(),
+    );
+    let c = Camera::new(11, 11, FRAC_PI_2, view_transform);
+
+    let image = c.render(w);
+    let color = image.pixel_at(5, 5);
+
+    assert_eq!(round(color.r()), 0.38066);
+    assert_eq!(round(color.g()), 0.47583);
+    assert_eq!(round(color.b()), 0.28550);
+}

--- a/src/primitives/material_test.rs
+++ b/src/primitives/material_test.rs
@@ -1,89 +1,88 @@
-#[cfg(test)]
-mod material_test {
-    use crate::{Color, Material, Point, PointLight, Vector};
-    use rust_catch::tests;
+use crate::{Color, Material, Point, PointLight, Vector};
 
-    fn round(v: f64) -> f64 {
-        const SIG_FIGS: f64 = 100000.0;
-        (v * SIG_FIGS).round() / SIG_FIGS
-    }
+fn round(v: f64) -> f64 {
+    const SIG_FIGS: f64 = 100000.0;
+    (v * SIG_FIGS).round() / SIG_FIGS
+}
 
-    tests! {
-        test("Lighting with the eye between the light and the surface") {
-            let m = Material::default();
-            let position = Point::new(0.0, 0.0, 0.0);
+#[test]
+fn lighting_with_the_eye_between_the_light_and_the_surface() {
+    let m = Material::default();
+    let position = Point::new(0.0, 0.0, 0.0);
 
-            let eyev = Vector::new(0.0, 0.0, -1.0);
-            let normalv = Vector::new(0.0, 0.0, -1.0);
+    let eyev = Vector::new(0.0, 0.0, -1.0);
+    let normalv = Vector::new(0.0, 0.0, -1.0);
 
-            let light = PointLight::new(Point::new(0.0, 0.0, -10.0), Color::new(1.0, 1.0, 1.0));
+    let light = PointLight::new(Point::new(0.0, 0.0, -10.0), Color::new(1.0, 1.0, 1.0));
 
-            let result = m.lighting(light, position, eyev, normalv, false);
-            assert_eq!(result, Color::new(1.9, 1.9, 1.9));
-        }
+    let result = m.lighting(light, position, eyev, normalv, false);
+    assert_eq!(result, Color::new(1.9, 1.9, 1.9));
+}
 
-        test("Lighting with the eye between light and surface eye offset 45") {
-            let m = Material::default();
-            let position = Point::new(0.0, 0.0, 0.0);
-            let eyev = Vector::new(0.0, 2f64.sqrt() / 2.0, -2f64.sqrt() / 2.0);
-            let normalv = Vector::new(0.0, 0.0, -1.0);
-            let light = PointLight::new(Point::new(0.0, 0.0, -10.0), Color::new(1.0, 1.0, 1.0));
+#[test]
+fn lighting_with_the_eye_between_light_and_surface_eye_offset_45() {
+    let m = Material::default();
+    let position = Point::new(0.0, 0.0, 0.0);
+    let eyev = Vector::new(0.0, 2f64.sqrt() / 2.0, -2f64.sqrt() / 2.0);
+    let normalv = Vector::new(0.0, 0.0, -1.0);
+    let light = PointLight::new(Point::new(0.0, 0.0, -10.0), Color::new(1.0, 1.0, 1.0));
 
-            let result = m.lighting(light, position, eyev, normalv, false);
-            assert_eq!(result, Color::new(1.0, 1.0, 1.0));
-        }
+    let result = m.lighting(light, position, eyev, normalv, false);
+    assert_eq!(result, Color::new(1.0, 1.0, 1.0));
+}
 
-        test("Lighting with eye opposite surface lighting offset 45") {
-            let m = Material::default();
-            let position = Point::new(0.0, 0.0, 0.0);
+#[test]
+fn lighting_with_eye_opposite_surface_lighting_offset_45() {
+    let m = Material::default();
+    let position = Point::new(0.0, 0.0, 0.0);
 
-            let eyev = Vector::new(0.0, 0.0, -1.0);
-            let normalv = Vector::new(0.0, 0.0, -1.0);
-            let light = PointLight::new(Point::new(0.0, 10.0, -10.0), Color::new(1.0, 1.0, 1.0));
+    let eyev = Vector::new(0.0, 0.0, -1.0);
+    let normalv = Vector::new(0.0, 0.0, -1.0);
+    let light = PointLight::new(Point::new(0.0, 10.0, -10.0), Color::new(1.0, 1.0, 1.0));
 
-            let result = m.lighting(light, position, eyev, normalv, false);
-            assert_eq!(round(result.r()), 0.7364);
-            assert_eq!(round(result.g()), 0.7364);
-            assert_eq!(round(result.b()), 0.7364);
-        }
+    let result = m.lighting(light, position, eyev, normalv, false);
+    assert_eq!(round(result.r()), 0.7364);
+    assert_eq!(round(result.g()), 0.7364);
+    assert_eq!(round(result.b()), 0.7364);
+}
 
-        test("Lighting with eye in the path of the reflection vector") {
-            let m = Material::default();
-            let position = Point::new(0.0, 0.0, 0.0);
+#[test]
+fn lighting_with_eye_in_the_path_of_the_reflection_vector() {
+    let m = Material::default();
+    let position = Point::new(0.0, 0.0, 0.0);
 
-            let eyev = Vector::new(0.0, -2f64.sqrt() / 2.0, -2f64.sqrt() / 2.0);
-            let normalv = Vector::new(0.0, 0.0, -1.0);
-            let light = PointLight::new(Point::new(0.0, 10.0, -10.0), Color::new(1.0, 1.0, 1.0));
+    let eyev = Vector::new(0.0, -2f64.sqrt() / 2.0, -2f64.sqrt() / 2.0);
+    let normalv = Vector::new(0.0, 0.0, -1.0);
+    let light = PointLight::new(Point::new(0.0, 10.0, -10.0), Color::new(1.0, 1.0, 1.0));
 
-            let result = m.lighting(light, position, eyev, normalv, false);
-            assert_eq!(round(result.r()), 1.6364);
-            assert_eq!(round(result.g()), 1.6364);
-            assert_eq!(round(result.b()), 1.6364);
-        }
+    let result = m.lighting(light, position, eyev, normalv, false);
+    assert_eq!(round(result.r()), 1.6364);
+    assert_eq!(round(result.g()), 1.6364);
+    assert_eq!(round(result.b()), 1.6364);
+}
 
-        test("Lighting with the light behind the surface") {
-            let m = Material::default();
-            let position = Point::new(0.0, 0.0, 0.0);
+#[test]
+fn lighting_with_the_light_behind_the_surface() {
+    let m = Material::default();
+    let position = Point::new(0.0, 0.0, 0.0);
 
-            let eyev = Vector::new(0.0, 0.0, -1.0);
-            let normalv = Vector::new(0.0, 0.0, -1.0);
-            let light = PointLight::new(Point::new(0.0, 0.0, 10.0), Color::new(1.0, 1.0, 1.0));
+    let eyev = Vector::new(0.0, 0.0, -1.0);
+    let normalv = Vector::new(0.0, 0.0, -1.0);
+    let light = PointLight::new(Point::new(0.0, 0.0, 10.0), Color::new(1.0, 1.0, 1.0));
 
-            let result = m.lighting(light, position, eyev, normalv, false);
-            assert_eq!(result, Color::new(0.1, 0.1, 0.1));
-        }
-    }
+    let result = m.lighting(light, position, eyev, normalv, false);
+    assert_eq!(result, Color::new(0.1, 0.1, 0.1));
+}
 
-    #[test]
-    fn lighting_with_the_surface_in_shadow() {
-        let m = Material::default();
-        let position = Point::new(0.0, 0.0, 0.0);
-        let eyev = Vector::new(0.0, 0.0, -1.0);
-        let normalv = Vector::new(0.0, 0.0, -1.0);
-        let light = PointLight::new(Point::new(0.0, 0.0, -10.0), Color::white());
-        let in_shadow = true;
+#[test]
+fn lighting_with_the_surface_in_shadow() {
+    let m = Material::default();
+    let position = Point::new(0.0, 0.0, 0.0);
+    let eyev = Vector::new(0.0, 0.0, -1.0);
+    let normalv = Vector::new(0.0, 0.0, -1.0);
+    let light = PointLight::new(Point::new(0.0, 0.0, -10.0), Color::white());
+    let in_shadow = true;
 
-        let result = m.lighting(light, position, eyev, normalv, in_shadow);
-        assert_eq!(result, Color::new(0.1, 0.1, 0.1));
-    }
+    let result = m.lighting(light, position, eyev, normalv, in_shadow);
+    assert_eq!(result, Color::new(0.1, 0.1, 0.1));
 }

--- a/src/primitives/mod.rs
+++ b/src/primitives/mod.rs
@@ -1,3 +1,6 @@
+// This is a library to the code won't be used yet
+#![allow(dead_code)]
+
 // Code
 mod camera;
 mod intersection;
@@ -19,6 +22,8 @@ pub use shape::Sphere;
 pub use world::World;
 
 // Tests
+#[cfg(test)]
+mod camera_test;
 #[cfg(test)]
 mod material_test;
 #[cfg(test)]

--- a/src/primitives/mod.rs
+++ b/src/primitives/mod.rs
@@ -1,16 +1,14 @@
+// Code
 mod camera;
 mod intersection;
 mod intersection_stats;
 mod material;
-mod material_test;
 mod point_light;
 mod ray;
-mod ray_test;
 mod shape;
-mod shape_test;
 mod world;
-mod world_test;
 
+// Exports
 pub use camera::Camera;
 pub use intersection::Intersection;
 pub use intersection_stats::IntersectionStats;
@@ -19,3 +17,13 @@ pub use point_light::PointLight;
 pub use ray::Ray;
 pub use shape::Sphere;
 pub use world::World;
+
+// Tests
+#[cfg(test)]
+mod material_test;
+#[cfg(test)]
+mod ray_test;
+#[cfg(test)]
+mod shape_test;
+#[cfg(test)]
+mod world_test;

--- a/src/primitives/ray_test.rs
+++ b/src/primitives/ray_test.rs
@@ -1,225 +1,238 @@
-#[cfg(test)]
-mod ray_test {
-    use super::super::{Intersection, Ray, Sphere};
-    use crate::{Matrix4x4, Point, Vector};
-    use rust_catch::tests;
 
-    tests! {
-        test("Creating and querying a ray") {
-            let origin = Point::new(1.0, 2.0, 3.0);
-            let direction = Vector::new(4.0, 5.0, 6.0);
+use super::{Intersection, Ray, Sphere};
+use crate::{Matrix4x4, Point, Vector};
 
-            let ray = Ray::new(origin, direction);
+#[test]
+fn creating_and_querying_a_ray() {
+    let origin = Point::new(1.0, 2.0, 3.0);
+    let direction = Vector::new(4.0, 5.0, 6.0);
 
-            assert_eq!(ray.origin(), origin);
-            assert_eq!(ray.direction(), direction);
-        }
+    let ray = Ray::new(origin, direction);
 
-        test("Computing a point from a distance") {
-            let ray = Ray::new(Point::new(2.0, 3.0, 4.0), Vector::new(1.0, 0.0, 0.0));
+    assert_eq!(ray.origin(), origin);
+    assert_eq!(ray.direction(), direction);
+}
 
-            assert_eq!(ray.position(0.0), Point::new(2.0, 3.0, 4.0));
-            assert_eq!(ray.position(1.0), Point::new(3.0, 3.0, 4.0));
-            assert_eq!(ray.position(-1.0), Point::new(1.0, 3.0, 4.0));
-            assert_eq!(ray.position(2.5), Point::new(4.5, 3.0, 4.0));
-        }
+#[test]
+fn computing_a_point_from_a_distance() {
+    let ray = Ray::new(Point::new(2.0, 3.0, 4.0), Vector::new(1.0, 0.0, 0.0));
 
-        test("A ray intersects a sphere at 2 locations") {
-            let r = Ray::new(Point::new(0.0, 0.0, -5.0), Vector::new(0.0, 0.0, 1.0));
-            let s = Sphere::default();
+    assert_eq!(ray.position(0.0), Point::new(2.0, 3.0, 4.0));
+    assert_eq!(ray.position(1.0), Point::new(3.0, 3.0, 4.0));
+    assert_eq!(ray.position(-1.0), Point::new(1.0, 3.0, 4.0));
+    assert_eq!(ray.position(2.5), Point::new(4.5, 3.0, 4.0));
+}
 
-            let intersections = r.intersects(s);
-            assert_eq!(intersections[0].t(), 4.0);
-            assert_eq!(intersections[1].t(), 6.0);
-        }
+#[test]
+fn a_ray_intersects_a_sphere_at_2_locations() {
+    let r = Ray::new(Point::new(0.0, 0.0, -5.0), Vector::new(0.0, 0.0, 1.0));
+    let s = Sphere::default();
 
-        test("A ray intersects a sphere at a tangent") {
-            let r = Ray::new(Point::new(0.0, 1.0, -5.0), Vector::new(0.0, 0.0, 1.0));
-            let s = Sphere::default();
-            let i = r.intersects(s);
+    let intersections = r.intersects(s);
+    assert_eq!(intersections[0].t(), 4.0);
+    assert_eq!(intersections[1].t(), 6.0);
+}
 
-            assert_eq!(i[0].t(), 5.0);
-            assert_eq!(i[1].t(), 5.0);
-        }
+#[test]
+fn a_ray_intersects_a_sphere_at_a_tangent() {
+    let r = Ray::new(Point::new(0.0, 1.0, -5.0), Vector::new(0.0, 0.0, 1.0));
+    let s = Sphere::default();
+    let i = r.intersects(s);
 
-        test("A ray misses a sphere") {
-            let r = Ray::new(Point::new(0.0, 2.0, -5.0), Vector::new(0.0, 0.0, 1.0));
-            let s = Sphere::default();
+    assert_eq!(i[0].t(), 5.0);
+    assert_eq!(i[1].t(), 5.0);
+}
 
-            let i = r.intersects(s);
+#[test]
+fn a_ray_misses_a_sphere() {
+    let r = Ray::new(Point::new(0.0, 2.0, -5.0), Vector::new(0.0, 0.0, 1.0));
+    let s = Sphere::default();
 
-            assert_eq!(i.len(), 0);
-        }
+    let i = r.intersects(s);
 
-        test("A ray originates inside a sphere") {
-            let r = Ray::new(Point::new(0.0, 0.0, 0.0), Vector::new(0.0, 0.0, 1.0));
-            let s = Sphere::default();
+    assert_eq!(i.len(), 0);
+}
 
-            let i = r.intersects(s);
-            assert_eq!(i[0].t(), -1.0);
-            assert_eq!(i[1].t(), 1.0);
-        }
+#[test]
+fn a_ray_originates_inside_a_sphere() {
+    let r = Ray::new(Point::new(0.0, 0.0, 0.0), Vector::new(0.0, 0.0, 1.0));
+    let s = Sphere::default();
 
-        test("A sphere is behind a ray") {
-            let r = Ray::new(Point::new(0.0, 0.0, 5.0), Vector::new(0.0, 0.0, 1.0));
-            let s = Sphere::default();
+    let i = r.intersects(s);
+    assert_eq!(i[0].t(), -1.0);
+    assert_eq!(i[1].t(), 1.0);
+}
 
-            let i = r.intersects(s);
-            assert_eq!(i[0].t(), -6.0);
-            assert_eq!(i[1].t(), -4.0);
-            assert_eq!(i[0].object(), s);
-            assert_eq!(i[1].object(), s);
-        }
+#[test]
+fn a_sphere_is_behind_a_ray() {
+    let r = Ray::new(Point::new(0.0, 0.0, 5.0), Vector::new(0.0, 0.0, 1.0));
+    let s = Sphere::default();
 
-        test("An intersection encapsulates t and object") {
-            let s = Sphere::default();
-            let i = Intersection::new(3.5, s);
+    let i = r.intersects(s);
+    assert_eq!(i[0].t(), -6.0);
+    assert_eq!(i[1].t(), -4.0);
+    assert_eq!(i[0].object(), s);
+    assert_eq!(i[1].object(), s);
+}
 
-            assert_eq!(i.t(), 3.5);
-            assert_eq!(i.object(), s);
-        }
+#[test]
+fn an_intersection_encapsulates_t_and_object() {
+    let s = Sphere::default();
+    let i = Intersection::new(3.5, s);
 
-        test("The hit when all intersections have positive t") {
-            let s = Sphere::default();
-            let i1 = Intersection::new(1.0, s);
-            let i2 = Intersection::new(2.0, s);
+    assert_eq!(i.t(), 3.5);
+    assert_eq!(i.object(), s);
+}
 
-            let intersections = vec![i1, i2];
-            let hit = Intersection::hit(intersections).unwrap();
+#[test]
+fn the_hit_when_all_intersections_have_positive_t() {
+    let s = Sphere::default();
+    let i1 = Intersection::new(1.0, s);
+    let i2 = Intersection::new(2.0, s);
 
-            assert_eq!(hit, i1);
-        }
+    let intersections = vec![i1, i2];
+    let hit = Intersection::hit(intersections).unwrap();
 
-        test("The hit when some intersections have negative t") {
-            let s = Sphere::default();
-            let i1 = Intersection::new(-1.0, s);
-            let i2 = Intersection::new(1.0, s);
+    assert_eq!(hit, i1);
+}
 
-            let intersections = vec![i1, i2];
-            let hit = Intersection::hit(intersections).unwrap();
+#[test]
+fn the_hit_when_some_intersections_have_negative_t() {
+    let s = Sphere::default();
+    let i1 = Intersection::new(-1.0, s);
+    let i2 = Intersection::new(1.0, s);
 
-            assert_eq!(hit, i2);
-        }
+    let intersections = vec![i1, i2];
+    let hit = Intersection::hit(intersections).unwrap();
 
-        test("The hit when all intersections have negative t") {
-            let s = Sphere::default();
-            let i1 = Intersection::new(-2.0, s);
-            let i2 = Intersection::new(-1.0, s);
+    assert_eq!(hit, i2);
+}
 
-            let intersections = vec![i1, i2];
-            let hit = Intersection::hit(intersections);
+#[test]
+fn the_hit_when_all_intersections_have_negative_t() {
+    let s = Sphere::default();
+    let i1 = Intersection::new(-2.0, s);
+    let i2 = Intersection::new(-1.0, s);
 
-            assert_eq!(hit, None);
-        }
+    let intersections = vec![i1, i2];
+    let hit = Intersection::hit(intersections);
 
-        test("The hit is always the lowest nonnegative intersection") {
-            let s = Sphere::default();
-            let i1 = Intersection::new(5.0, s);
-            let i2 = Intersection::new(7.0, s);
-            let i3 = Intersection::new(-3.0, s);
-            let i4 = Intersection::new(2.0, s);
-            let hit = Intersection::hit(vec![i1, i2, i3, i4]).unwrap();
+    assert_eq!(hit, None);
+}
 
-            assert_eq!(hit, i4);
-        }
+#[test]
+fn the_hit_is_always_the_lowest_nonnegative_intersection() {
+    let s = Sphere::default();
+    let i1 = Intersection::new(5.0, s);
+    let i2 = Intersection::new(7.0, s);
+    let i3 = Intersection::new(-3.0, s);
+    let i4 = Intersection::new(2.0, s);
+    let hit = Intersection::hit(vec![i1, i2, i3, i4]).unwrap();
 
-        test("Translate a ray") {
-            let r1 = Ray::new(Point::new(1.0, 2.0, 3.0), Vector::new(0.0, 1.0, 0.0));
-            let m = Matrix4x4::translation(3.0, 4.0, 5.0);
-            let r2 = r1.transform(m);
+    assert_eq!(hit, i4);
+}
 
-            assert_eq!(r2.origin(), Point::new(4.0, 6.0, 8.0));
-            assert_eq!(r2.direction(), Vector::new(0.0, 1.0, 0.0));
-        }
+#[test]
+fn translate_a_ray() {
+    let r1 = Ray::new(Point::new(1.0, 2.0, 3.0), Vector::new(0.0, 1.0, 0.0));
+    let m = Matrix4x4::translation(3.0, 4.0, 5.0);
+    let r2 = r1.transform(m);
 
-        test("Scale a ray") {
-            let r1 = Ray::new(Point::new(1.0, 2.0, 3.0), Vector::new(0.0, 1.0, 0.0));
-            let m = Matrix4x4::scaling(2.0, 3.0, 4.0);
-            let r2 = r1.transform(m);
+    assert_eq!(r2.origin(), Point::new(4.0, 6.0, 8.0));
+    assert_eq!(r2.direction(), Vector::new(0.0, 1.0, 0.0));
+}
 
-            assert_eq!(r2.origin(), Point::new(2.0, 6.0, 12.0));
-            assert_eq!(r2.direction(), Vector::new(0.0, 3.0, 0.0));
-        }
+#[test]
+fn scale_a_ray() {
+    let r1 = Ray::new(Point::new(1.0, 2.0, 3.0), Vector::new(0.0, 1.0, 0.0));
+    let m = Matrix4x4::scaling(2.0, 3.0, 4.0);
+    let r2 = r1.transform(m);
 
-        test("A spheres default transformation") {
-            let s = Sphere::default();
-            assert_eq!(s.transformation(), Matrix4x4::identity());
-        }
+    assert_eq!(r2.origin(), Point::new(2.0, 6.0, 12.0));
+    assert_eq!(r2.direction(), Vector::new(0.0, 3.0, 0.0));
+}
 
-        test("Set a spheres transformation") {
-            let t = Matrix4x4::translation(2.0, 3.0, 4.0);
-            let s2 = Sphere::sphere_from_transformation(t);
+#[test]
+fn a_spheres_default_transformation() {
+    let s = Sphere::default();
+    assert_eq!(s.transformation(), Matrix4x4::identity());
+}
 
-            assert_eq!(s2.transformation(), t);
-        }
+#[test]
+fn set_a_spheres_transformation() {
+    let t = Matrix4x4::translation(2.0, 3.0, 4.0);
+    let s2 = Sphere::sphere_from_transformation(t);
 
-        test("Intersecting a scaled sphere with a ray") {
-            let r = Ray::new(Point::new(0.0, 0.0, -5.0), Vector::new(0.0, 0.0, 1.0));
-            let s = Sphere::sphere_from_transformation(Matrix4x4::scaling(2.0, 2.0, 2.0));
+    assert_eq!(s2.transformation(), t);
+}
 
-            let intersections = r.intersects(s);
+#[test]
+fn intersecting_a_scaled_sphere_with_a_ray() {
+    let r = Ray::new(Point::new(0.0, 0.0, -5.0), Vector::new(0.0, 0.0, 1.0));
+    let s = Sphere::sphere_from_transformation(Matrix4x4::scaling(2.0, 2.0, 2.0));
 
-            assert_eq!(intersections.len(), 2);
-            assert_eq!(intersections[0].t(), 3.0);
-            assert_eq!(intersections[1].t(), 7.0);
-        }
+    let intersections = r.intersects(s);
 
-        test("Intersecting a translated sphere with a ray") {
-            let r = Ray::new(Point::new(0.0, 0.0, -5.0), Vector::new(0.0, 0.0, 1.0));
-            let s = Sphere::sphere_from_transformation(Matrix4x4::translation(5.0, 0.0, 0.0));
+    assert_eq!(intersections.len(), 2);
+    assert_eq!(intersections[0].t(), 3.0);
+    assert_eq!(intersections[1].t(), 7.0);
+}
 
-            let intersections = r.intersects(s);
+#[test]
+fn intersecting_a_translated_sphere_with_a_ray() {
+    let r = Ray::new(Point::new(0.0, 0.0, -5.0), Vector::new(0.0, 0.0, 1.0));
+    let s = Sphere::sphere_from_transformation(Matrix4x4::translation(5.0, 0.0, 0.0));
 
-            assert_eq!(intersections.len(), 0);
-        }
-    }
+    let intersections = r.intersects(s);
 
-    #[test]
-    fn precomputing_the_state_of_an_intersection() {
-        let r = Ray::new(Point::new(0.0, 0.0, -5.0), Vector::new(0.0, 0.0, 1.0));
-        let shape = Sphere::default();
-        let i = Intersection::new(4.0, shape);
+    assert_eq!(intersections.len(), 0);
+}
 
-        let comps = i.prepare_computations(r);
-        assert_eq!(comps.t(), i.t());
-        assert_eq!(comps.object(), i.object());
-        assert_eq!(comps.point(), Point::new(0.0, 0.0, -1.0));
-        assert_eq!(comps.eyev(), Vector::new(0.0, 0.0, -1.0));
-        assert_eq!(comps.normalv(), Vector::new(0.0, 0.0, -1.0));
-    }
+#[test]
+fn precomputing_the_state_of_an_intersection() {
+    let r = Ray::new(Point::new(0.0, 0.0, -5.0), Vector::new(0.0, 0.0, 1.0));
+    let shape = Sphere::default();
+    let i = Intersection::new(4.0, shape);
 
-    #[test]
-    fn the_hit_when_an_intersection_occurs_on_the_outside() {
-        let ray = Ray::new(Point::new(0.0, 0.0, -5.0), Vector::new(0.0, 0.0, 1.0));
-        let shape = Sphere::default();
-        let i = Intersection::new(4.0, shape);
+    let comps = i.prepare_computations(r);
+    assert_eq!(comps.t(), i.t());
+    assert_eq!(comps.object(), i.object());
+    assert_eq!(comps.point(), Point::new(0.0, 0.0, -1.0));
+    assert_eq!(comps.eyev(), Vector::new(0.0, 0.0, -1.0));
+    assert_eq!(comps.normalv(), Vector::new(0.0, 0.0, -1.0));
+}
 
-        let comps = i.prepare_computations(ray);
-        assert_eq!(comps.inside(), false);
-    }
+#[test]
+fn the_hit_when_an_intersection_occurs_on_the_outside() {
+    let ray = Ray::new(Point::new(0.0, 0.0, -5.0), Vector::new(0.0, 0.0, 1.0));
+    let shape = Sphere::default();
+    let i = Intersection::new(4.0, shape);
 
-    #[test]
-    fn the_hit_when_an_intersection_occurs_on_the_inside() {
-        let ray = Ray::new(Point::new(0.0, 0.0, 0.0), Vector::new(0.0, 0.0, 1.0));
-        let shape = Sphere::default();
-        let i = Intersection::new(1.0, shape);
+    let comps = i.prepare_computations(ray);
+    assert_eq!(comps.inside(), false);
+}
 
-        let comps = i.prepare_computations(ray);
-        assert_eq!(comps.point(), Point::new(0.0, 0.0, 1.0));
-        assert_eq!(comps.eyev(), Vector::new(0.0, 0.0, -1.0));
-        assert_eq!(comps.inside(), true);
-        assert_eq!(comps.normalv(), Vector::new(0.0, 0.0, -1.0));
-    }
+#[test]
+fn the_hit_when_an_intersection_occurs_on_the_inside() {
+    let ray = Ray::new(Point::new(0.0, 0.0, 0.0), Vector::new(0.0, 0.0, 1.0));
+    let shape = Sphere::default();
+    let i = Intersection::new(1.0, shape);
 
-    #[test]
-    fn the_hit_should_offset_the_point() {
-        let ray = Ray::new(Point::new(0.0, 0.0, -5.0), Vector::new(0.0, 0.0, 1.0));
-        let shape = Sphere::sphere_from_transformation(Matrix4x4::translation(0.0, 0.0, 1.0));
+    let comps = i.prepare_computations(ray);
+    assert_eq!(comps.point(), Point::new(0.0, 0.0, 1.0));
+    assert_eq!(comps.eyev(), Vector::new(0.0, 0.0, -1.0));
+    assert_eq!(comps.inside(), true);
+    assert_eq!(comps.normalv(), Vector::new(0.0, 0.0, -1.0));
+}
 
-        let i = Intersection::new(5.0, shape);
-        let comps = i.prepare_computations(ray);
+#[test]
+fn the_hit_should_offset_the_point() {
+    let ray = Ray::new(Point::new(0.0, 0.0, -5.0), Vector::new(0.0, 0.0, 1.0));
+    let shape = Sphere::sphere_from_transformation(Matrix4x4::translation(0.0, 0.0, 1.0));
 
-        assert!(comps.over_point().z() < (-std::f32::EPSILON as f64 / 2.0));
-        assert!(comps.point().z() > comps.over_point().z());
-    }
+    let i = Intersection::new(5.0, shape);
+    let comps = i.prepare_computations(ray);
+
+    assert!(comps.over_point().z() < (-std::f32::EPSILON as f64 / 2.0));
+    assert!(comps.point().z() > comps.over_point().z());
 }

--- a/src/primitives/shape_test.rs
+++ b/src/primitives/shape_test.rs
@@ -1,70 +1,71 @@
-#[cfg(test)]
-mod shape_test {
-    use super::super::Sphere;
-    use crate::{Material, Matrix4x4, Point, Vector};
-    use rust_catch::tests;
-    use std::f64::consts::PI;
 
-    fn round(v: f64) -> f64 {
-        const SIG_FIGS: f64 = 100000.0;
-        (v * SIG_FIGS).round() / SIG_FIGS
-    }
+use super::Sphere;
+use crate::{Material, Matrix4x4, Point, Vector};
+use std::f64::consts::PI;
 
-    tests! {
-        test("The normal on different axis") {
-            let s = Sphere::default();
-            let n1 = s.normal_at(Point::new(1.0, 0.0, 0.0));
-            assert_eq!(n1, Vector::new(1.0, 0.0, 0.0));
-            let n2 = s.normal_at(Point::new(0.0, 1.0, 0.0));
-            assert_eq!(n2, Vector::new(0.0, 1.0, 0.0));
-            let n3 = s.normal_at(Point::new(0.0, 0.0, 1.0));
-            assert_eq!(n3, Vector::new(0.0, 0.0, 1.0));
+fn round(v: f64) -> f64 {
+    const SIG_FIGS: f64 = 100000.0;
+    (v * SIG_FIGS).round() / SIG_FIGS
+}
 
-            let p = 3f64.sqrt() / 3.0;
-            let n4 = s.normal_at(Point::new(p, p, p));
-            assert_eq!(n4, Vector::new(p, p, p));
-        }
+#[test]
+fn the_normal_on_different_axis() {
+    let s = Sphere::default();
+    let n1 = s.normal_at(Point::new(1.0, 0.0, 0.0));
+    assert_eq!(n1, Vector::new(1.0, 0.0, 0.0));
+    let n2 = s.normal_at(Point::new(0.0, 1.0, 0.0));
+    assert_eq!(n2, Vector::new(0.0, 1.0, 0.0));
+    let n3 = s.normal_at(Point::new(0.0, 0.0, 1.0));
+    assert_eq!(n3, Vector::new(0.0, 0.0, 1.0));
 
-        test("The normal is a normalized vector") {
-            let s = Sphere::default();
-            let p = 3f64.sqrt() / 3.0;
-            let n = s.normal_at(Point::new(p, p, p));
-            assert_eq!(n, n.normalize());
-        }
+    let p = 3f64.sqrt() / 3.0;
+    let n4 = s.normal_at(Point::new(p, p, p));
+    assert_eq!(n4, Vector::new(p, p, p));
+}
 
-        test("Computing the normal on a translated sphere") {
-            let s = Sphere::sphere_from_transformation(Matrix4x4::translation(0.0, 1.0, 0.0));
-            let n = s.normal_at(Point::new(0.0, 1.70711, -0.70711));
+#[test]
+fn the_normal_is_a_normalized_vector() {
+    let s = Sphere::default();
+    let p = 3f64.sqrt() / 3.0;
+    let n = s.normal_at(Point::new(p, p, p));
+    assert_eq!(n, n.normalize());
+}
 
-            assert_eq!(round(n.x()), 0.0);
-            assert_eq!(round(n.y()), 0.70711);
-            assert_eq!(round(n.z()), -0.70711);
-            assert_eq!(round(n.w()), 0.0);
-        }
+#[test]
+fn computing_the_normal_on_a_translated_sphere() {
+    let s = Sphere::sphere_from_transformation(Matrix4x4::translation(0.0, 1.0, 0.0));
+    let n = s.normal_at(Point::new(0.0, 1.70711, -0.70711));
 
-        test("Computing the normal on a transformed sphere") {
-            //let m = Matrix4x4::scaling(1.0, 0.5, 1.0).rotate_z(PI / 5.0);
-            let m = Matrix4x4::scaling(1.0, 0.5, 1.0).rotate_z(PI / 5.0);
-            let s = Sphere::sphere_from_transformation(m);
+    assert_eq!(round(n.x()), 0.0);
+    assert_eq!(round(n.y()), 0.70711);
+    assert_eq!(round(n.z()), -0.70711);
+    assert_eq!(round(n.w()), 0.0);
+}
 
-            let p = 2f64.sqrt() / 2.0;
-            let n = s.normal_at(Point::new(0.0, p, -p));
-            assert_eq!(round(n.x()), 0.0);
-            assert_eq!(round(n.y()), 0.97014);
-            assert_eq!(round(n.z()), -0.24254);
-            assert_eq!(round(n.w()), 0.0);
-        }
+#[test]
+fn computing_the_normal_on_a_transformed_sphere() {
+    //let m = Matrix4x4::scaling(1.0, 0.5, 1.0).rotate_z(PI / 5.0);
+    let m = Matrix4x4::scaling(1.0, 0.5, 1.0).rotate_z(PI / 5.0);
+    let s = Sphere::sphere_from_transformation(m);
 
-        test("A sphere has a default material") {
-            let s = Sphere::default();
-            assert_eq!(s.material(), Material::default());
-        }
+    let p = 2f64.sqrt() / 2.0;
+    let n = s.normal_at(Point::new(0.0, p, -p));
+    assert_eq!(round(n.x()), 0.0);
+    assert_eq!(round(n.y()), 0.97014);
+    assert_eq!(round(n.z()), -0.24254);
+    assert_eq!(round(n.w()), 0.0);
+}
 
-        test("A sphere may be assigned a material") {
-            let mut m = Material::default();
-            m.ambient = 1.0;
-            let s = Sphere::new(Matrix4x4::identity(), m);
-            assert_eq!(s.material(), m);
-        }
-    }
+#[test]
+fn a_sphere_has_a_default_material() {
+    let s = Sphere::default();
+    assert_eq!(s.material(), Material::default());
+}
+
+#[test]
+fn a_sphere_may_be_assigned_a_material() {
+    let mut m = Material::default();
+    m.ambient = 1.0;
+    let s = Sphere::new(Matrix4x4::identity(), m);
+    assert_eq!(s.material(), m);
 }


### PR DESCRIPTION
Removed rust_catch because:

1. I wasn't really using any of it's features other than string based naming
2. Because it makes heavy use of syn it takes a long time to compile
3. It gets in the way of IDE support which makes it better to write tests using built in features